### PR TITLE
fix: misbehaviour on Android's back button press

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,14 +3,18 @@ import '@ethersproject/shims';
 import React, { useEffect, useState } from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import {
+  createStackNavigator,
+  TransitionPresets,
+} from '@react-navigation/stack';
 import { NavigationContainer } from '@react-navigation/native';
+
 import OnboardingStack from './onboarding/OnboardingStack';
 import MainStack from './main/MainStack';
 import Loader from './shared/Loader';
 import './shared/locales';
 
-const Tab = createBottomTabNavigator();
+const Stack = createStackNavigator();
 
 function App() {
   // TODO: use redux persist instead of AsyncStorage
@@ -30,30 +34,29 @@ function App() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <NavigationContainer>
-        <Tab.Navigator
+        <Stack.Navigator
           initialRouteName={onboarded ? 'Main' : 'Onboarding'}
           screenOptions={{
             headerShown: false,
-            tabBarShowLabel: false,
           }}
         >
-          <Tab.Screen
+          <Stack.Screen
             name="Onboarding"
             component={OnboardingStack}
             options={{
+              ...TransitionPresets.ModalPresentationIOS,
               title: 'onboarding',
-              tabBarStyle: { display: 'none' },
             }}
           />
-          <Tab.Screen
+          <Stack.Screen
             name="Main"
             component={MainStack}
             options={{
+              gestureEnabled: false,
               title: 'Main',
-              tabBarStyle: { display: 'none' },
             }}
           />
-        </Tab.Navigator>
+        </Stack.Navigator>
       </NavigationContainer>
     </GestureHandlerRootView>
   );

--- a/src/main/MainStack.tsx
+++ b/src/main/MainStack.tsx
@@ -20,6 +20,7 @@ type MainTabStackParamList = {
   Setting: any;
 };
 const Tab = createBottomTabNavigator<MainTabStackParamList>();
+
 const MainStack = () => {
   const isDarkMode = useColorScheme() === 'dark';
   return (
@@ -52,33 +53,14 @@ const MainStack = () => {
         tabBarInactiveBackgroundColor: isDarkMode
           ? styledColors.black
           : styledColors.light,
+        headerShown: false,
       })}
     >
-      <Tab.Screen
-        name="Wallet"
-        options={{ headerShown: false }}
-        component={WalletScreen}
-      />
-      <Tab.Screen
-        name="Exchange"
-        options={{ headerShown: false }}
-        component={ExchangeScreen}
-      />
-      <Tab.Screen
-        name="Home"
-        options={{ headerShown: false }}
-        component={HomeScreen}
-      />
-      <Tab.Screen
-        name="Earn"
-        options={{ headerShown: false }}
-        component={EarnScreen}
-      />
-      <Tab.Screen
-        name="Setting"
-        options={{ headerShown: false }}
-        component={SettingScreen}
-      />
+      <Tab.Screen name="Wallet" component={WalletScreen} />
+      <Tab.Screen name="Exchange" component={ExchangeScreen} />
+      <Tab.Screen name="Home" component={HomeScreen} />
+      <Tab.Screen name="Earn" component={EarnScreen} />
+      <Tab.Screen name="Setting" component={SettingScreen} />
     </Tab.Navigator>
   );
 };

--- a/src/main/MainStack.tsx
+++ b/src/main/MainStack.tsx
@@ -26,6 +26,7 @@ const MainStack = () => {
   return (
     <Tab.Navigator
       initialRouteName="Home"
+      backBehavior="none"
       screenOptions={({ route }) => ({
         tabBarIcon: ({ color, size }) => {
           if (route.name === 'Wallet') {


### PR DESCRIPTION
## Description

Because of how our navigation was setup, using the back button on Android gave unexpected behaviours such as browsing back to the onboarding stack but also browsing to the first tab (which is `Wallet` in our current Home stack).

To fix this, we first changed the first navigator from tabs to stack. Two main reasons for this change being the first that tabs where disabled and thus it was pointless to use and the second one being that stack navigation is a better choice for the root navigation of the app. This means that if we need to navigate away from the Home stack, we'd better do so with a stack navigator wrapper.

After changing the Root navigator, we just had to disable back behaviour on Home Stack to avoid the usage of the back button to browse between tabs. This is the expected behaviour and on press, the app should close itself because that's Android's native behaviour.

## Related links
- #78 

## Bug's repro steps

- Open up the App on an Android device
- Do the onboarding if required
- When placed on the Home of the app, press Android's back button
  - Check that the user is moved the the first tab -> Wallet
- On second Android's back button press
  - Check that the user is moved to the onboarding screen (location configuration)

## Screenshots and videos

| _Before_ | _After_ |
| :---: | :---: |
| <video src='https://user-images.githubusercontent.com/21087992/242565984-48c3513f-36a5-4967-b6f6-4c84e06ffc06.mov' width=500> | <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/e1befbed-e8ec-437f-bd19-edc6c0159ceb' width=500> |

