### PR TITLE
feat: add react-native-localization to detect device's language

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -505,6 +505,8 @@ PODS:
     - TOCropViewController
   - RNKeychain (8.1.1):
     - React-Core
+  - RNLocalize (3.0.0):
+    - React-Core
   - RNPermissions (3.8.0):
     - React-Core
   - RNReanimated (2.17.0):
@@ -628,6 +630,7 @@ DEPENDENCIES:
   - RNHoleView (from `../node_modules/react-native-hole-view`)
   - RNImageCropPicker (from `../node_modules/react-native-image-crop-picker`)
   - RNKeychain (from `../node_modules/react-native-keychain`)
+  - RNLocalize (from `../node_modules/react-native-localize`)
   - RNPermissions (from `../node_modules/react-native-permissions`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
@@ -760,6 +763,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-image-crop-picker"
   RNKeychain:
     :path: "../node_modules/react-native-keychain"
+  RNLocalize:
+    :path: "../node_modules/react-native-localize"
   RNPermissions:
     :path: "../node_modules/react-native-permissions"
   RNReanimated:
@@ -850,6 +855,7 @@ SPEC CHECKSUMS:
   RNHoleView: 2a1929191141775058fc0a9fd79836edc200640a
   RNImageCropPicker: 14fe1c29298fb4018f3186f455c475ab107da332
   RNKeychain: ff836453cba46938e0e9e4c22e43d43fa2c90333
+  RNLocalize: 5944c97d2fe8150913a51ddd5eab4e23a82bd80d
   RNPermissions: 215c54462104b3925b412b0fb3c9c497b21c358b
   RNReanimated: f186e85d9f28c9383d05ca39e11dd194f59093ec
   RNScreens: 218801c16a2782546d30bd2026bb625c0302d70f

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-native-image-crop-picker": "^0.39.0",
     "react-native-image-picker": "^5.3.1",
     "react-native-keychain": "^8.1.1",
+    "react-native-localize": "^3.0.0",
     "react-native-modal": "^13.0.1",
     "react-native-paper": "^5.7.2",
     "react-native-permissions": "^3.8.0",

--- a/src/shared/locales/index.ts
+++ b/src/shared/locales/index.ts
@@ -1,11 +1,15 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
+import { findBestLanguageTag } from 'react-native-localize';
+
 import common_en from './en/common.json';
 import common_de from './de/common.json';
 import home_en from './en/home.json';
 import home_de from './de/home.json';
 import onboarding_en from './en/onboarding.json';
 import onboarding_de from './de/onboarding.json';
+
+const fallbackLng = findBestLanguageTag(['en', 'de'])?.languageTag;
 
 i18n.use(initReactI18next).init({
   resources: {
@@ -24,8 +28,7 @@ i18n.use(initReactI18next).init({
       },
     },
   },
-  lng: 'en',
-  fallbackLng: 'en',
+  fallbackLng: fallbackLng || 'en',
   interpolation: {
     escapeValue: false,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7724,6 +7724,11 @@ react-native-keychain@^8.1.1:
   resolved "https://registry.npmjs.org/react-native-keychain/-/react-native-keychain-8.1.1.tgz"
   integrity sha512-8fxgeHKwGcL657eAYpdBTkDIxNhbIHI+kyyO0Yac2dgVAN184JoIwQcW2z6snahwDaCObQOu0biLFHnsH+4KSg==
 
+react-native-localize@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-localize/-/react-native-localize-3.0.0.tgz#41536e8aca8a148fd96d495d3d5cf710e25b2855"
+  integrity sha512-B8taYRLuLIYDzBTKIglA3K6ntjaEwbk6mwQ72ogZYl5ovM00NnpbiZ3sRq8KRVe/V1NGczxT33uVqG6BUWGWhg==
+
 react-native-modal@^13.0.1:
   version "13.0.1"
   resolved "https://registry.npmjs.org/react-native-modal/-/react-native-modal-13.0.1.tgz"


### PR DESCRIPTION
## Description

By adding `react-native-localize`, we have access to `findBestLanguageTag` function that configures the fallback language based on device's preferred language.

## Related links

- Closes #85 

## Proof

### Android

| _Before_ | _After_ |
| :--: | :--: |
| <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/0bf687f5-3646-4957-a76e-3f3fac4232f2'> | <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/513ec202-a8e0-4aa2-93e5-e00286b6cf73'> |

### iOS

| _German_ | _English_ |
| :---: | :---: |
| <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/fb90eb38-94f3-42be-a92c-fd8e08505b82'> | <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/028a44a9-ad6d-467c-8fc0-b1f29a817972'> |

## Testing instructions

- Set up your device to either German or any other language
- Open the app
  - Check that app's content is in german for german set devices
  - Check that app's content is in english for any other case 



