### PR TITLE
feat: add final receive qr screen

### DIFF
--- a/src/main/home/HomeScreen.tsx
+++ b/src/main/home/HomeScreen.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import SwitchSelector from 'react-native-switch-selector';
 import { fontStyle, styledColors } from '../../styles';
 import SendStack from './send/SendStack';
-import { ReceiveQRScreen } from './receive/ReceiveQRScreen';
+import { ReceiveScreen } from './receive/ReceiveScreen/';
 import { RootStackParamList } from 'src/App';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 
@@ -88,7 +88,7 @@ const HomeScreen: React.FC<HomeScreenProps> = ({}) => {
               ...styles.walletCardStyle,
             }}
           >
-            <ReceiveQRScreen />
+            <ReceiveScreen />
           </View>
         )}
       </View>

--- a/src/main/home/receive/ReceiveAmountInputScreen/hooks.ts
+++ b/src/main/home/receive/ReceiveAmountInputScreen/hooks.ts
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { EUnit } from './types';
 
 const INITIAL_AMOUNT = '0';
-const EXCHANGE_RATE = 0.005;
+export const EXCHANGE_RATE = 0.005;
 
 // TODO: improve input logic handling
 // TODO: get exchange rate from internet
@@ -25,10 +25,10 @@ export const useReceiveInput = () => {
   const updateInputs = (value: string) => {
     if (unit === EUnit.USD) {
       setAmount(value);
-      setEqValue((Number(value) * EXCHANGE_RATE).toString());
+      setEqValue((Number(value) / EXCHANGE_RATE).toString());
     } else {
       setAmount(value);
-      setEqValue((Number(value) / EXCHANGE_RATE).toString());
+      setEqValue((Number(value) * EXCHANGE_RATE).toString());
     }
   };
 

--- a/src/main/home/receive/ReceiveAmountInputScreen/index.tsx
+++ b/src/main/home/receive/ReceiveAmountInputScreen/index.tsx
@@ -28,7 +28,9 @@ type ReceiveAmountInputProps = NativeStackScreenProps<
 
 // TODO: implement in-house keyboard
 // TODO: improve L&F by using flex
-export const ReceiveAmountInputScreen = ({}: ReceiveAmountInputProps) => {
+export const ReceiveAmountInputScreen = ({
+  navigation,
+}: ReceiveAmountInputProps) => {
   const { t } = useTranslation();
   const isDarkMode = useColorScheme() === 'dark';
   const profilePicture = useProfilePicture();
@@ -52,7 +54,7 @@ export const ReceiveAmountInputScreen = ({}: ReceiveAmountInputProps) => {
   };
 
   const goToGeneratedQR = () =>
-    console.log('Continue to QR generated screen (TBD)');
+    navigation.navigate('ReceiveQR', { amount: input.value, unit: input.unit });
 
   useLayoutEffect(() => {
     if (inputRef) {

--- a/src/main/home/receive/ReceiveAmountInputScreen/index.tsx
+++ b/src/main/home/receive/ReceiveAmountInputScreen/index.tsx
@@ -20,6 +20,7 @@ import { useProfilePicture, useUsername, useWallet } from 'src/shared/hooks';
 
 import { useReceiveInput } from './hooks';
 import { ReceiveStackParamList } from '../ReceiveStack';
+import { EUnit } from './types';
 
 type ReceiveAmountInputProps = NativeStackScreenProps<
   ReceiveStackParamList,
@@ -54,7 +55,9 @@ export const ReceiveAmountInputScreen = ({
   };
 
   const goToGeneratedQR = () =>
-    navigation.navigate('ReceiveQR', { amount: input.value, unit: input.unit });
+    navigation.navigate('ReceiveQR', {
+      amount: Number(input.unit === EUnit.USD ? input.value : eqInput.value),
+    });
 
   useLayoutEffect(() => {
     if (inputRef) {

--- a/src/main/home/receive/ReceiveQRScreen.tsx
+++ b/src/main/home/receive/ReceiveQRScreen.tsx
@@ -17,8 +17,10 @@ import { useProfilePicture, useUsername, useWallet } from 'src/shared/hooks';
 import Loader from 'src/shared/Loader';
 
 import ShareControl from './ShareControl';
+import { useTranslation } from 'react-i18next';
 
 export const ReceiveQRScreen = () => {
+  const { t } = useTranslation();
   const isDarkMode = useColorScheme() === 'dark';
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList, 'Main'>>();
@@ -95,7 +97,7 @@ export const ReceiveQRScreen = () => {
               ...(isDarkMode ? buttonStyle.dark : buttonStyle.white),
             }}
           >
-            Request
+            {t('common.request')}
           </Text>
         </TouchableOpacity>
       </View>

--- a/src/main/home/receive/ReceiveQRScreen/index.tsx
+++ b/src/main/home/receive/ReceiveQRScreen/index.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
-import { StatusBar, StyleSheet, View, useColorScheme } from 'react-native';
+import {
+  StatusBar,
+  StyleSheet,
+  Text,
+  View,
+  useColorScheme,
+} from 'react-native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { ReceiveStackParamList } from '../ReceiveStack';
-import { styledColors } from 'src/styles';
+import { fontStyle, styledColors } from 'src/styles';
 import { useProfilePicture, useUsername, useWallet } from 'src/shared/hooks';
 import QRCode from 'react-native-qrcode-svg';
 
@@ -25,8 +31,13 @@ export const ReceiveQRScreen = ({ route }: ReceiveQRProps) => {
     backgroundColor: isDarkMode ? styledColors.black : styledColors.light,
   };
 
-  const walletCardBackgroundColor = isDarkMode
+  const primaryTextColor = isDarkMode ? styledColors.white : styledColors.black;
+  const secondaryTextColor = isDarkMode
     ? styledColors.gray
+    : styledColors.white;
+
+  const walletCardBackgroundColor = isDarkMode
+    ? styledColors.darkGray
     : styledColors.white;
 
   return (
@@ -41,7 +52,14 @@ export const ReceiveQRScreen = ({ route }: ReceiveQRProps) => {
           { backgroundColor: walletCardBackgroundColor },
         ]}
       >
-        <View></View>
+        <View style={styles.requestedAmount}>
+          <Text style={{ color: secondaryTextColor }}>
+            ${amount} {unit}
+          </Text>
+          <Text style={[styles.mainAmount, { color: primaryTextColor }]}>
+            {amount} {unit}
+          </Text>
+        </View>
         <View style={styles.qrCode}>
           <QRCode
             value={JSON.stringify({
@@ -71,6 +89,15 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     marginTop: 80,
     marginHorizontal: 16,
+    paddingVertical: 36,
+  },
+  requestedAmount: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  mainAmount: {
+    ...fontStyle.fontH2,
   },
   qrCode: {
     padding: 8,

--- a/src/main/home/receive/ReceiveQRScreen/index.tsx
+++ b/src/main/home/receive/ReceiveQRScreen/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import {
+  ScrollView,
   StatusBar,
   StyleSheet,
   Text,
@@ -71,70 +72,74 @@ export const ReceiveQRScreen = ({ navigation, route }: ReceiveQRProps) => {
         barStyle={isDarkMode ? 'light-content' : 'dark-content'}
         backgroundColor={backgroundStyle.backgroundColor}
       />
-      <View
-        style={[
-          styles.walletCard,
-          { backgroundColor: walletCardBackgroundColor },
-        ]}
-      >
-        <View style={styles.requestedAmount}>
-          <Text style={{ color: secondaryTextColor }}>
-            {mainUnit !== EUnit.USD && '$'}
-            {eqAmount} {mainUnit === EUnit.USD ? EUnit.QUAI : EUnit.USD}
-          </Text>
-          <Text style={[styles.mainAmount, { color: primaryTextColor }]}>
-            {mainUnit === EUnit.USD && '$'}
-            {mainAmount} {mainUnit}
-          </Text>
-          <TouchableOpacity onPress={onSwap} style={styles.exchangeUnit}>
-            <Text style={{ color: primaryTextColor }}>{EUnit.USD}</Text>
-            <ExchangeIcon
-              color={isDarkMode ? styledColors.white : styledColors.black}
+      <ScrollView>
+        <View
+          style={[
+            styles.walletCard,
+            { backgroundColor: walletCardBackgroundColor },
+          ]}
+        >
+          <View style={styles.requestedAmount}>
+            <Text style={{ color: secondaryTextColor }}>
+              {mainUnit !== EUnit.USD && '$'}
+              {eqAmount} {mainUnit === EUnit.USD ? EUnit.QUAI : EUnit.USD}
+            </Text>
+            <Text style={[styles.mainAmount, { color: primaryTextColor }]}>
+              {mainUnit === EUnit.USD && '$'}
+              {mainAmount} {mainUnit}
+            </Text>
+            <TouchableOpacity onPress={onSwap} style={styles.exchangeUnit}>
+              <Text style={{ color: primaryTextColor }}>{EUnit.USD}</Text>
+              <ExchangeIcon
+                color={isDarkMode ? styledColors.white : styledColors.black}
+              />
+            </TouchableOpacity>
+          </View>
+          <View style={styles.qrCode}>
+            <QRCode
+              value={JSON.stringify({
+                address: wallet?.address,
+                username,
+                amount,
+              })}
+              logo={{ uri: profilePicture }}
+              logoSize={50}
+              logoBackgroundColor="transparent"
+              logoBorderRadius={50}
+              size={140}
             />
+          </View>
+          <View style={styles.userInfo}>
+            <Text style={[styles.username, { color: primaryTextColor }]}>
+              {username}
+            </Text>
+            <Text
+              style={[fontStyle.fontParagraph, { color: secondaryTextColor }]}
+            >
+              {wallet && wallet?.address.slice(0, 8)}...
+              {wallet?.address.slice(-8)}
+            </Text>
+          </View>
+          <View style={styles.shareControl}>
+            <ShareControl />
+          </View>
+        </View>
+        <View>
+          <TouchableOpacity onPress={share} style={styles.shareButton}>
+            <Text style={{ color: styledColors.white }}>
+              {t('common.share')}
+            </Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.learnMore} onPress={goToQuaiPayInfo}>
+            <Text style={styles.learnMoreText}>Learn more about QuaiPay</Text>
           </TouchableOpacity>
         </View>
-        <View style={styles.qrCode}>
-          <QRCode
-            value={JSON.stringify({
-              address: wallet?.address,
-              username,
-              amount,
-            })}
-            logo={{ uri: profilePicture }}
-            logoSize={50}
-            logoBackgroundColor="transparent"
-            logoBorderRadius={50}
-            size={140}
-          />
-        </View>
-        <View style={styles.userInfo}>
-          <Text style={[styles.username, { color: primaryTextColor }]}>
-            {username}
+        <TouchableOpacity style={styles.completeButton} onPress={complete}>
+          <Text style={{ color: styledColors.white }}>
+            {t('receive.qrScreen.complete')}
           </Text>
-          <Text
-            style={[fontStyle.fontParagraph, { color: secondaryTextColor }]}
-          >
-            {wallet && wallet?.address.slice(0, 8)}...
-            {wallet?.address.slice(-8)}
-          </Text>
-        </View>
-        <View style={styles.shareControl}>
-          <ShareControl />
-        </View>
-      </View>
-      <View>
-        <TouchableOpacity onPress={share} style={styles.shareButton}>
-          <Text style={{ color: styledColors.white }}>{t('common.share')}</Text>
         </TouchableOpacity>
-        <TouchableOpacity style={styles.learnMore} onPress={goToQuaiPayInfo}>
-          <Text style={styles.learnMoreText}>Learn more about QuaiPay</Text>
-        </TouchableOpacity>
-      </View>
-      <TouchableOpacity style={styles.completeButton} onPress={complete}>
-        <Text style={{ color: styledColors.white }}>
-          {t('receive.qrScreen.complete')}
-        </Text>
-      </TouchableOpacity>
+      </ScrollView>
     </SafeAreaView>
   );
 };

--- a/src/main/home/receive/ReceiveQRScreen/index.tsx
+++ b/src/main/home/receive/ReceiveQRScreen/index.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { StatusBar, StyleSheet, useColorScheme } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { ReceiveStackParamList } from '../ReceiveStack';
+import { styledColors } from 'src/styles';
+
+type ReceiveQRProps = NativeStackScreenProps<
+  ReceiveStackParamList,
+  'ReceiveQR'
+>;
+
+export const ReceiveQRScreen = ({}: ReceiveQRProps) => {
+  const isDarkMode = useColorScheme() === 'dark';
+
+  const backgroundStyle = {
+    backgroundColor: isDarkMode ? styledColors.black : styledColors.light,
+  };
+
+  return (
+    <SafeAreaView style={[backgroundStyle, styles.safeAreaView]}>
+      <StatusBar
+        barStyle={isDarkMode ? 'light-content' : 'dark-content'}
+        backgroundColor={backgroundStyle.backgroundColor}
+      />
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeAreaView: {
+    width: '100%',
+    height: '100%',
+  },
+});

--- a/src/main/home/receive/ReceiveQRScreen/index.tsx
+++ b/src/main/home/receive/ReceiveQRScreen/index.tsx
@@ -13,6 +13,7 @@ import { ReceiveStackParamList } from '../ReceiveStack';
 import { fontStyle, styledColors } from 'src/styles';
 import { useProfilePicture, useUsername, useWallet } from 'src/shared/hooks';
 import QRCode from 'react-native-qrcode-svg';
+import ShareControl from '../ShareControl';
 
 type ReceiveQRProps = NativeStackScreenProps<
   ReceiveStackParamList,
@@ -86,6 +87,9 @@ export const ReceiveQRScreen = ({ route }: ReceiveQRProps) => {
             {wallet?.address.slice(-8)}
           </Text>
         </View>
+        <View style={styles.shareControl}>
+          <ShareControl />
+        </View>
       </View>
     </SafeAreaView>
   );
@@ -127,5 +131,9 @@ const styles = StyleSheet.create({
   username: {
     ...fontStyle.fontH2,
     fontSize: 20,
+  },
+  shareControl: {
+    marginTop: 20,
+    alignItems: 'center',
   },
 });

--- a/src/main/home/receive/ReceiveQRScreen/index.tsx
+++ b/src/main/home/receive/ReceiveQRScreen/index.tsx
@@ -75,6 +75,17 @@ export const ReceiveQRScreen = ({ route }: ReceiveQRProps) => {
             size={140}
           />
         </View>
+        <View style={styles.userInfo}>
+          <Text style={[styles.username, { color: primaryTextColor }]}>
+            {username}
+          </Text>
+          <Text
+            style={[fontStyle.fontParagraph, { color: secondaryTextColor }]}
+          >
+            {wallet && wallet?.address.slice(0, 8)}...
+            {wallet?.address.slice(-8)}
+          </Text>
+        </View>
       </View>
     </SafeAreaView>
   );
@@ -107,5 +118,14 @@ const styles = StyleSheet.create({
     borderColor: styledColors.lightGray,
     marginLeft: 'auto',
     marginRight: 'auto',
+  },
+  userInfo: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 12,
+  },
+  username: {
+    ...fontStyle.fontH2,
+    fontSize: 20,
   },
 });

--- a/src/main/home/receive/ReceiveQRScreen/index.tsx
+++ b/src/main/home/receive/ReceiveQRScreen/index.tsx
@@ -1,22 +1,33 @@
 import React from 'react';
-import { StatusBar, StyleSheet, useColorScheme } from 'react-native';
+import { StatusBar, StyleSheet, View, useColorScheme } from 'react-native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { ReceiveStackParamList } from '../ReceiveStack';
 import { styledColors } from 'src/styles';
+import { useProfilePicture, useUsername, useWallet } from 'src/shared/hooks';
+import QRCode from 'react-native-qrcode-svg';
 
 type ReceiveQRProps = NativeStackScreenProps<
   ReceiveStackParamList,
   'ReceiveQR'
 >;
 
-export const ReceiveQRScreen = ({}: ReceiveQRProps) => {
+export const ReceiveQRScreen = ({ route }: ReceiveQRProps) => {
+  const { amount, unit } = route.params;
+
   const isDarkMode = useColorScheme() === 'dark';
+  const profilePicture = useProfilePicture();
+  const username = useUsername();
+  const wallet = useWallet();
 
   const backgroundStyle = {
     backgroundColor: isDarkMode ? styledColors.black : styledColors.light,
   };
+
+  const walletCardBackgroundColor = isDarkMode
+    ? styledColors.gray
+    : styledColors.white;
 
   return (
     <SafeAreaView style={[backgroundStyle, styles.safeAreaView]}>
@@ -24,6 +35,29 @@ export const ReceiveQRScreen = ({}: ReceiveQRProps) => {
         barStyle={isDarkMode ? 'light-content' : 'dark-content'}
         backgroundColor={backgroundStyle.backgroundColor}
       />
+      <View
+        style={[
+          styles.walletCard,
+          { backgroundColor: walletCardBackgroundColor },
+        ]}
+      >
+        <View></View>
+        <View style={styles.qrCode}>
+          <QRCode
+            value={JSON.stringify({
+              address: wallet?.address,
+              username,
+              amount,
+              unit,
+            })}
+            logo={{ uri: profilePicture }}
+            logoSize={50}
+            logoBackgroundColor="transparent"
+            logoBorderRadius={50}
+            size={140}
+          />
+        </View>
+      </View>
     </SafeAreaView>
   );
 };
@@ -32,5 +66,19 @@ const styles = StyleSheet.create({
   safeAreaView: {
     width: '100%',
     height: '100%',
+  },
+  walletCard: {
+    borderRadius: 8,
+    marginTop: 80,
+    marginHorizontal: 16,
+  },
+  qrCode: {
+    padding: 8,
+    borderWidth: 1,
+    borderRadius: 8,
+    backgroundColor: styledColors.white,
+    borderColor: styledColors.lightGray,
+    marginLeft: 'auto',
+    marginRight: 'auto',
   },
 });

--- a/src/main/home/receive/ReceiveQRScreen/index.tsx
+++ b/src/main/home/receive/ReceiveQRScreen/index.tsx
@@ -3,6 +3,7 @@ import {
   StatusBar,
   StyleSheet,
   Text,
+  TouchableOpacity,
   View,
   useColorScheme,
 } from 'react-native';
@@ -14,6 +15,7 @@ import { fontStyle, styledColors } from 'src/styles';
 import { useProfilePicture, useUsername, useWallet } from 'src/shared/hooks';
 import QRCode from 'react-native-qrcode-svg';
 import ShareControl from '../ShareControl';
+import { useTranslation } from 'react-i18next';
 
 type ReceiveQRProps = NativeStackScreenProps<
   ReceiveStackParamList,
@@ -24,9 +26,13 @@ export const ReceiveQRScreen = ({ route }: ReceiveQRProps) => {
   const { amount, unit } = route.params;
 
   const isDarkMode = useColorScheme() === 'dark';
+  const { t } = useTranslation();
   const profilePicture = useProfilePicture();
   const username = useUsername();
   const wallet = useWallet();
+
+  const share = () => console.log('Share triggered');
+  const goToQuaiPayInfo = () => console.log('Go to QuaiPay Info');
 
   const backgroundStyle = {
     backgroundColor: isDarkMode ? styledColors.black : styledColors.light,
@@ -91,6 +97,12 @@ export const ReceiveQRScreen = ({ route }: ReceiveQRProps) => {
           <ShareControl />
         </View>
       </View>
+      <TouchableOpacity onPress={share} style={styles.shareButton}>
+        <Text style={{ color: styledColors.white }}>{t('common.share')}</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.learnMore} onPress={goToQuaiPayInfo}>
+        <Text style={styles.learnMoreText}>Learn more about QuaiPay</Text>
+      </TouchableOpacity>
     </SafeAreaView>
   );
 };
@@ -102,7 +114,7 @@ const styles = StyleSheet.create({
   },
   walletCard: {
     borderRadius: 8,
-    marginTop: 80,
+    marginTop: 12,
     marginHorizontal: 16,
     paddingVertical: 36,
   },
@@ -135,5 +147,22 @@ const styles = StyleSheet.create({
   shareControl: {
     marginTop: 20,
     alignItems: 'center',
+  },
+  shareButton: {
+    borderRadius: 8,
+    backgroundColor: styledColors.normal,
+    marginTop: 32,
+    alignSelf: 'center',
+    paddingVertical: 16,
+    paddingHorizontal: 140,
+  },
+  learnMore: {
+    marginTop: 12,
+    marginBottom: 20,
+  },
+  learnMoreText: {
+    ...fontStyle.fontSmallText,
+    color: styledColors.gray,
+    textDecorationLine: 'underline',
   },
 });

--- a/src/main/home/receive/ReceiveQRScreen/index.tsx
+++ b/src/main/home/receive/ReceiveQRScreen/index.tsx
@@ -23,7 +23,7 @@ type ReceiveQRProps = NativeStackScreenProps<
   'ReceiveQR'
 >;
 
-export const ReceiveQRScreen = ({ route }: ReceiveQRProps) => {
+export const ReceiveQRScreen = ({ navigation, route }: ReceiveQRProps) => {
   const { amount, unit } = route.params;
 
   const isDarkMode = useColorScheme() === 'dark';
@@ -34,6 +34,7 @@ export const ReceiveQRScreen = ({ route }: ReceiveQRProps) => {
 
   const share = () => console.log('Share triggered');
   const goToQuaiPayInfo = () => console.log('Go to QuaiPay Info');
+  const complete = () => navigation.goBack();
 
   const backgroundStyle = {
     backgroundColor: isDarkMode ? styledColors.black : styledColors.light,
@@ -98,11 +99,18 @@ export const ReceiveQRScreen = ({ route }: ReceiveQRProps) => {
           <ShareControl />
         </View>
       </View>
-      <TouchableOpacity onPress={share} style={styles.shareButton}>
-        <Text style={{ color: styledColors.white }}>{t('common.share')}</Text>
-      </TouchableOpacity>
-      <TouchableOpacity style={styles.learnMore} onPress={goToQuaiPayInfo}>
-        <Text style={styles.learnMoreText}>Learn more about QuaiPay</Text>
+      <View>
+        <TouchableOpacity onPress={share} style={styles.shareButton}>
+          <Text style={{ color: styledColors.white }}>{t('common.share')}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.learnMore} onPress={goToQuaiPayInfo}>
+          <Text style={styles.learnMoreText}>Learn more about QuaiPay</Text>
+        </TouchableOpacity>
+      </View>
+      <TouchableOpacity style={styles.completeButton} onPress={complete}>
+        <Text style={{ color: styledColors.white }}>
+          {t('receive.qrScreen.complete')}
+        </Text>
       </TouchableOpacity>
     </SafeAreaView>
   );
@@ -152,7 +160,7 @@ const styles = StyleSheet.create({
   shareButton: {
     borderRadius: 8,
     backgroundColor: styledColors.normal,
-    marginTop: 32,
+    marginTop: 16,
     alignSelf: 'center',
     paddingVertical: 16,
     paddingHorizontal: 140,
@@ -165,5 +173,12 @@ const styles = StyleSheet.create({
     ...fontStyle.fontSmallText,
     color: styledColors.gray,
     textDecorationLine: 'underline',
+  },
+  completeButton: {
+    alignItems: 'center',
+    backgroundColor: styledColors.gray,
+    marginHorizontal: 30,
+    borderRadius: 8,
+    paddingVertical: 16,
   },
 });

--- a/src/main/home/receive/ReceiveQRScreen/index.tsx
+++ b/src/main/home/receive/ReceiveQRScreen/index.tsx
@@ -9,13 +9,14 @@ import {
 } from 'react-native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import QRCode from 'react-native-qrcode-svg';
+import { useTranslation } from 'react-i18next';
 
-import { ReceiveStackParamList } from '../ReceiveStack';
 import { fontStyle, styledColors } from 'src/styles';
 import { useProfilePicture, useUsername, useWallet } from 'src/shared/hooks';
-import QRCode from 'react-native-qrcode-svg';
+
+import { ReceiveStackParamList } from '../ReceiveStack';
 import ShareControl from '../ShareControl';
-import { useTranslation } from 'react-i18next';
 
 type ReceiveQRProps = NativeStackScreenProps<
   ReceiveStackParamList,

--- a/src/main/home/receive/ReceiveScreen/index.tsx
+++ b/src/main/home/receive/ReceiveScreen/index.tsx
@@ -16,10 +16,10 @@ import { buttonStyle, fontStyle, styledColors } from 'src/styles';
 import { useProfilePicture, useUsername, useWallet } from 'src/shared/hooks';
 import Loader from 'src/shared/Loader';
 
-import ShareControl from './ShareControl';
+import ShareControl from '../ShareControl';
 import { useTranslation } from 'react-i18next';
 
-export const ReceiveQRScreen = () => {
+export const ReceiveScreen = () => {
   const { t } = useTranslation();
   const isDarkMode = useColorScheme() === 'dark';
   const navigation =

--- a/src/main/home/receive/ReceiveStack.tsx
+++ b/src/main/home/receive/ReceiveStack.tsx
@@ -3,14 +3,21 @@ import React, { useCallback } from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useNavigation } from '@react-navigation/native';
 import { Pressable, Text, useColorScheme } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import FontAwesome5 from 'react-native-vector-icons/FontAwesome5';
 
 import { styledColors } from 'src/styles';
+
 import { ReceiveAmountInputScreen } from './ReceiveAmountInputScreen';
-import { useTranslation } from 'react-i18next';
+import { ReceiveQRScreen } from './ReceiveQRScreen';
+import { EUnit } from './ReceiveAmountInputScreen/types';
 
 export type ReceiveStackParamList = {
-  ReceiveAmountInput: { amount: string } | undefined;
+  ReceiveAmountInput: undefined;
+  ReceiveQR: {
+    amount: string;
+    unit: EUnit;
+  };
 };
 
 const Stack = createNativeStackNavigator<ReceiveStackParamList>();
@@ -51,6 +58,24 @@ const ReceiveStack = () => {
           ),
         }}
         component={ReceiveAmountInputScreen}
+      />
+      <Stack.Screen
+        name="ReceiveQR"
+        options={{
+          headerStyle: { backgroundColor },
+          headerShadowVisible: false,
+          headerTitleAlign: 'center',
+          headerTitle: () => (
+            <Text style={textStyle}>{t('common.request')}</Text>
+          ),
+          // TODO: fix goBack functionality
+          headerLeft: () => (
+            <Pressable style={buttonStyle} onPress={goBack}>
+              <FontAwesome5 name="chevron-left" color={textColor} size={24} />
+            </Pressable>
+          ),
+        }}
+        component={ReceiveQRScreen}
       />
     </Stack.Navigator>
   );

--- a/src/main/home/receive/ReceiveStack.tsx
+++ b/src/main/home/receive/ReceiveStack.tsx
@@ -7,6 +7,7 @@ import FontAwesome5 from 'react-native-vector-icons/FontAwesome5';
 
 import { styledColors } from 'src/styles';
 import { ReceiveAmountInputScreen } from './ReceiveAmountInputScreen';
+import { useTranslation } from 'react-i18next';
 
 export type ReceiveStackParamList = {
   ReceiveAmountInput: { amount: string } | undefined;
@@ -17,6 +18,7 @@ const Stack = createNativeStackNavigator<ReceiveStackParamList>();
 // TODO: Implement actual header layout to
 //       avoid defining it on every screen
 const ReceiveStack = () => {
+  const { t } = useTranslation();
   const navigation = useNavigation();
   const isDarkMode = useColorScheme() === 'dark';
 
@@ -39,7 +41,9 @@ const ReceiveStack = () => {
           headerStyle: { backgroundColor },
           headerShadowVisible: false,
           headerTitleAlign: 'center',
-          headerTitle: () => <Text style={textStyle}>Request</Text>,
+          headerTitle: () => (
+            <Text style={textStyle}>{t('common.request')}</Text>
+          ),
           headerLeft: () => (
             <Pressable style={buttonStyle} onPress={goBack}>
               <FontAwesome5 name="chevron-left" color={textColor} size={24} />

--- a/src/main/home/receive/ReceiveStack.tsx
+++ b/src/main/home/receive/ReceiveStack.tsx
@@ -10,13 +10,11 @@ import { styledColors } from 'src/styles';
 
 import { ReceiveAmountInputScreen } from './ReceiveAmountInputScreen';
 import { ReceiveQRScreen } from './ReceiveQRScreen';
-import { EUnit } from './ReceiveAmountInputScreen/types';
 
 export type ReceiveStackParamList = {
   ReceiveAmountInput: undefined;
   ReceiveQR: {
-    amount: string;
-    unit: EUnit;
+    amount: number;
   };
 };
 

--- a/src/shared/locales/de/common.json
+++ b/src/shared/locales/de/common.json
@@ -1,4 +1,5 @@
 {
   "continue": "Weiter",
-  "request": "Anfrage"
+  "request": "Anfrage",
+  "share": "Teilen"
 }

--- a/src/shared/locales/de/common.json
+++ b/src/shared/locales/de/common.json
@@ -1,3 +1,4 @@
 {
-  "continue": "Weiter"
+  "continue": "Weiter",
+  "request": "Anfrage"
 }

--- a/src/shared/locales/de/receive.json
+++ b/src/shared/locales/de/receive.json
@@ -1,0 +1,5 @@
+{
+  "qrScreen": {
+    "complete": "Complete"
+  }
+}

--- a/src/shared/locales/en/common.json
+++ b/src/shared/locales/en/common.json
@@ -1,3 +1,4 @@
 {
-  "continue": "Continue"
+  "continue": "Continue",
+  "request": "Request"
 }

--- a/src/shared/locales/en/common.json
+++ b/src/shared/locales/en/common.json
@@ -1,4 +1,5 @@
 {
   "continue": "Continue",
-  "request": "Request"
+  "request": "Request",
+  "share": "Share"
 }

--- a/src/shared/locales/en/receive.json
+++ b/src/shared/locales/en/receive.json
@@ -1,0 +1,5 @@
+{
+  "qrScreen": {
+    "complete": "Complete"
+  }
+}

--- a/src/shared/locales/index.ts
+++ b/src/shared/locales/index.ts
@@ -6,6 +6,8 @@ import home_en from './en/home.json';
 import home_de from './de/home.json';
 import onboarding_en from './en/onboarding.json';
 import onboarding_de from './de/onboarding.json';
+import receive_en from './en/receive.json';
+import receive_de from './de/receive.json';
 
 i18n.use(initReactI18next).init({
   resources: {
@@ -14,6 +16,7 @@ i18n.use(initReactI18next).init({
         common: common_en,
         home: home_en,
         onboarding: onboarding_en,
+        receive: receive_en,
       },
     },
     de: {
@@ -21,6 +24,7 @@ i18n.use(initReactI18next).init({
         common: common_de,
         home: home_de,
         onboarding: onboarding_de,
+        receive: receive_de,
       },
     },
   },


### PR DESCRIPTION
## Description

Following up on #44, the last step for the request flow to be completed is to have the QR code generated with the amount information on it.

The new QR code provides the following information:

```js
{
  address,
  username,
  amount,   // in usd
}
```

Next steps for this screen are:
- Improving L&F
- Add functionality to CTAs
- Improve navigation setup for the app to be able to go back and forth

## Related links

- Closes #45 

## Demo

| _iOS_ | _Android_ |
| :---: | :---: |
| <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/9a497235-6265-49ca-b804-43c998929e50' width=400> | <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/4c3af009-c13a-4c4e-ac5d-796372348abb' width=400> |




