### PR TITLE
feat: improve app's navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import Loader from './shared/Loader';
 import './shared/locales';
 import { ThemeProvider } from './shared/context/themeContext';
-import { Navigation } from './navigation';
+import { Navigation } from './shared/navigation';
 
 function App() {
   // TODO: use redux persist instead of AsyncStorage

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,33 +3,11 @@ import '@ethersproject/shims';
 import React, { useEffect, useState } from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import {
-  createStackNavigator,
-  TransitionPresets,
-} from '@react-navigation/stack';
-import {
-  NavigationContainer,
-  NavigatorScreenParams,
-} from '@react-navigation/native';
 
-import OnboardingStack from './onboarding/OnboardingStack';
-import MainStack from './main/MainStack';
 import Loader from './shared/Loader';
 import './shared/locales';
-import ReceiveStack, {
-  ReceiveStackParamList,
-} from './main/home/receive/ReceiveStack';
 import { ThemeProvider } from './shared/context/themeContext';
-import SendStack, { SendStackParamList } from './main/home/send/SendStack';
-
-export type RootStackParamList = {
-  Onboarding: undefined;
-  Main: undefined;
-  ReceiveStack: NavigatorScreenParams<ReceiveStackParamList>;
-  SendStack: NavigatorScreenParams<SendStackParamList>;
-};
-
-const Stack = createStackNavigator<RootStackParamList>();
+import { Navigation } from './navigation';
 
 function App() {
   // TODO: use redux persist instead of AsyncStorage
@@ -49,45 +27,7 @@ function App() {
   return (
     <ThemeProvider>
       <GestureHandlerRootView style={{ flex: 1 }}>
-        <NavigationContainer>
-          <Stack.Navigator
-            initialRouteName={onboarded ? 'Main' : 'Onboarding'}
-            screenOptions={{
-              headerShown: false,
-            }}
-          >
-            <Stack.Screen
-              name="Onboarding"
-              component={OnboardingStack}
-              options={{
-                ...TransitionPresets.ModalPresentationIOS,
-                title: 'onboarding',
-              }}
-            />
-            <Stack.Screen
-              name="Main"
-              component={MainStack}
-              options={{
-                gestureEnabled: false,
-                title: 'Main',
-              }}
-            />
-            <Stack.Screen
-              name="ReceiveStack"
-              component={ReceiveStack}
-              options={{
-                title: 'ReceiveStack',
-              }}
-            />
-            <Stack.Screen
-              name="SendStack"
-              component={SendStack}
-              options={{
-                title: 'SendStack',
-              }}
-            />
-          </Stack.Navigator>
-        </NavigationContainer>
+        <Navigation onboarded={onboarded} />
       </GestureHandlerRootView>
     </ThemeProvider>
   );

--- a/src/main/home/HomeScreen.tsx
+++ b/src/main/home/HomeScreen.tsx
@@ -6,25 +6,21 @@ import {
   View,
   useColorScheme,
 } from 'react-native';
-import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useTranslation } from 'react-i18next';
 import SwitchSelector from 'react-native-switch-selector';
 
-import { RootStackParamList } from 'src/App';
+import { RootStackNavigationProps } from 'src/navigation';
 import { fontStyle, styledColors } from 'src/shared/styles';
 
 import SendStack from './send/SendStack';
 import { ReceiveScreen } from './receive/ReceiveScreen/';
-
-interface HomeScreenProps
-  extends NativeStackScreenProps<RootStackParamList, 'Main'> {}
 
 enum SwitchValue {
   Receive = 0,
   Send = 1,
 }
 
-const HomeScreen: React.FC<HomeScreenProps> = ({}) => {
+const HomeScreen: React.FC<RootStackNavigationProps<'Main'>> = ({}) => {
   const { t } = useTranslation();
   const isDarkMode = useColorScheme() === 'dark';
   const [switchValue, setSwitchValue] = useState<SwitchValue>(

--- a/src/main/home/HomeScreen.tsx
+++ b/src/main/home/HomeScreen.tsx
@@ -9,7 +9,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import SwitchSelector from 'react-native-switch-selector';
 
-import { RootStackNavigationProps } from 'src/navigation';
+import { RootStackNavigationProps } from 'src/shared/navigation';
 import { fontStyle, styledColors } from 'src/shared/styles';
 
 import SendStack from './send/SendStack';

--- a/src/main/home/receive/ReceiveAmountInputScreen/index.tsx
+++ b/src/main/home/receive/ReceiveAmountInputScreen/index.tsx
@@ -7,7 +7,6 @@ import {
   TouchableOpacity,
   Image,
 } from 'react-native';
-import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useTranslation } from 'react-i18next';
 
 import { fontStyle, styledColors } from 'src/shared/styles';
@@ -20,20 +19,14 @@ import {
 } from 'src/shared/components';
 
 import { useReceiveInput } from './hooks';
-import { ReceiveStackParamList } from '../ReceiveStack';
+import { ReceiveStackScreenProps } from '../ReceiveStack';
 import { EUnit } from './types';
-
-type ReceiveAmountInputProps = NativeStackScreenProps<
-  ReceiveStackParamList,
-  'ReceiveAmountInput'
->;
 
 // TODO: implement in-house keyboard
 // TODO: improve L&F by using flex
-export const ReceiveAmountInputScreen = ({
-  navigation,
-  route,
-}: ReceiveAmountInputProps) => {
+export const ReceiveAmountInputScreen: React.FC<
+  ReceiveStackScreenProps<'ReceiveAmountInput'>
+> = ({ navigation, route }) => {
   const { t } = useTranslation();
   const isDarkMode = useColorScheme() === 'dark';
   const profilePicture = useProfilePicture();

--- a/src/main/home/receive/ReceiveQRScreen/index.tsx
+++ b/src/main/home/receive/ReceiveQRScreen/index.tsx
@@ -14,7 +14,7 @@ import { QuaiPayContent } from 'src/shared/components';
 import { fontStyle, styledColors } from 'src/shared/styles';
 import { useProfilePicture, useUsername } from 'src/shared/hooks';
 import ExchangeIcon from 'src/shared/assets/exchange.svg';
-import { goHome } from 'src/shared/navigation';
+import { goHome } from 'src/shared/navigation/utils';
 
 import { ReceiveStackScreenProps } from '../ReceiveStack';
 import ShareControl from '../ShareControl';

--- a/src/main/home/receive/ReceiveQRScreen/index.tsx
+++ b/src/main/home/receive/ReceiveQRScreen/index.tsx
@@ -14,7 +14,7 @@ import { QuaiPayContent } from 'src/shared/components';
 import { fontStyle, styledColors } from 'src/shared/styles';
 import { useProfilePicture, useUsername } from 'src/shared/hooks';
 import ExchangeIcon from 'src/shared/assets/exchange.svg';
-import { goHome } from 'src/navigation';
+import { goHome } from 'src/shared/navigation';
 
 import { ReceiveStackScreenProps } from '../ReceiveStack';
 import ShareControl from '../ShareControl';

--- a/src/main/home/receive/ReceiveQRScreen/index.tsx
+++ b/src/main/home/receive/ReceiveQRScreen/index.tsx
@@ -15,6 +15,7 @@ import { QuaiPayContent } from 'src/shared/components';
 import { fontStyle, styledColors } from 'src/shared/styles';
 import { useProfilePicture, useUsername } from 'src/shared/hooks';
 import ExchangeIcon from 'src/shared/assets/exchange.svg';
+import { goHome } from 'src/navigation';
 
 import { ReceiveStackParamList } from '../ReceiveStack';
 import ShareControl from '../ShareControl';
@@ -26,7 +27,7 @@ type ReceiveQRProps = NativeStackScreenProps<
   'ReceiveQR'
 >;
 
-export const ReceiveQRScreen = ({ navigation, route }: ReceiveQRProps) => {
+export const ReceiveQRScreen = ({ route }: ReceiveQRProps) => {
   const { amount, wallet } = route.params;
 
   const isDarkMode = useColorScheme() === 'dark';
@@ -40,7 +41,6 @@ export const ReceiveQRScreen = ({ navigation, route }: ReceiveQRProps) => {
 
   const share = () => console.log('Share triggered');
   const goToQuaiPayInfo = () => console.log('Go to QuaiPay Info');
-  const complete = () => navigation.goBack();
   const onSwap = () => {
     const pastMain = mainAmount;
     const pastEq = eqAmount;
@@ -124,7 +124,7 @@ export const ReceiveQRScreen = ({ navigation, route }: ReceiveQRProps) => {
             <Text style={styles.learnMoreText}>Learn more about QuaiPay</Text>
           </TouchableOpacity>
         </View>
-        <TouchableOpacity style={styles.completeButton} onPress={complete}>
+        <TouchableOpacity style={styles.completeButton} onPress={goHome}>
           <Text style={{ color: styledColors.white }}>
             {t('receive.qrScreen.complete')}
           </Text>

--- a/src/main/home/receive/ReceiveQRScreen/index.tsx
+++ b/src/main/home/receive/ReceiveQRScreen/index.tsx
@@ -7,7 +7,6 @@ import {
   View,
   useColorScheme,
 } from 'react-native';
-import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import QRCode from 'react-native-qrcode-svg';
 import { useTranslation } from 'react-i18next';
 
@@ -17,17 +16,14 @@ import { useProfilePicture, useUsername } from 'src/shared/hooks';
 import ExchangeIcon from 'src/shared/assets/exchange.svg';
 import { goHome } from 'src/navigation';
 
-import { ReceiveStackParamList } from '../ReceiveStack';
+import { ReceiveStackScreenProps } from '../ReceiveStack';
 import ShareControl from '../ShareControl';
 import { EUnit } from '../ReceiveAmountInputScreen/types';
 import { EXCHANGE_RATE } from '../ReceiveAmountInputScreen/hooks';
 
-type ReceiveQRProps = NativeStackScreenProps<
-  ReceiveStackParamList,
-  'ReceiveQR'
->;
-
-export const ReceiveQRScreen = ({ route }: ReceiveQRProps) => {
+export const ReceiveQRScreen: React.FC<
+  ReceiveStackScreenProps<'ReceiveQR'>
+> = ({ route }) => {
   const { amount, wallet } = route.params;
 
   const isDarkMode = useColorScheme() === 'dark';

--- a/src/main/home/receive/ReceiveScreen/index.tsx
+++ b/src/main/home/receive/ReceiveScreen/index.tsx
@@ -7,10 +7,9 @@ import {
   View,
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
-import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import QRCode from 'react-native-qrcode-svg';
 
-import { RootStackParamList } from 'src/App';
+import { RootStackNavigationProps } from 'src/navigation';
 import { buttonStyle } from 'src/shared/styles';
 import { useProfilePicture, useUsername, useWallet } from 'src/shared/hooks';
 import Loader from 'src/shared/Loader';
@@ -25,8 +24,7 @@ export const ReceiveScreen = () => {
   const { t } = useTranslation();
   const styles = useThemedStyle(themedStyle);
   const isDarkMode = useColorScheme() === 'dark';
-  const navigation =
-    useNavigation<NativeStackNavigationProp<RootStackParamList, 'Main'>>();
+  const navigation = useNavigation<RootStackNavigationProps<'Main'>>();
   const profilePicture = useProfilePicture();
   const username = useUsername();
   const wallet = useWallet();

--- a/src/main/home/receive/ReceiveScreen/index.tsx
+++ b/src/main/home/receive/ReceiveScreen/index.tsx
@@ -9,7 +9,7 @@ import {
 import { useNavigation } from '@react-navigation/native';
 import QRCode from 'react-native-qrcode-svg';
 
-import { RootStackNavigationProps } from 'src/navigation';
+import { RootStackNavigationProps } from 'src/shared/navigation';
 import { buttonStyle } from 'src/shared/styles';
 import { useProfilePicture, useUsername, useWallet } from 'src/shared/hooks';
 import Loader from 'src/shared/Loader';

--- a/src/main/home/receive/ReceiveStack.tsx
+++ b/src/main/home/receive/ReceiveStack.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import { createStackNavigator } from '@react-navigation/stack';
+import {
+  createStackNavigator,
+  StackScreenProps,
+  StackNavigationProp,
+} from '@react-navigation/stack';
 
 import { ReceiveAmountInputScreen } from './ReceiveAmountInputScreen';
 import { ReceiveQRScreen } from './ReceiveQRScreen';
@@ -14,6 +18,13 @@ export type ReceiveStackParamList = {
     wallet: Wallet;
   };
 };
+
+export type ReceiveStackScreenProps<Route extends keyof ReceiveStackParamList> =
+  StackScreenProps<ReceiveStackParamList, Route>;
+
+export type ReceiveStackNavigationProps<
+  Route extends keyof ReceiveStackParamList,
+> = StackNavigationProp<ReceiveStackParamList, Route>;
 
 const Stack = createStackNavigator<ReceiveStackParamList>();
 

--- a/src/main/home/receive/ReceiveStack.tsx
+++ b/src/main/home/receive/ReceiveStack.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { createStackNavigator } from '@react-navigation/stack';
 
 import { ReceiveAmountInputScreen } from './ReceiveAmountInputScreen';
 import { ReceiveQRScreen } from './ReceiveQRScreen';
@@ -15,7 +15,7 @@ export type ReceiveStackParamList = {
   };
 };
 
-const Stack = createNativeStackNavigator<ReceiveStackParamList>();
+const Stack = createStackNavigator<ReceiveStackParamList>();
 
 const ReceiveStack = () => {
   return (

--- a/src/navigation.tsx
+++ b/src/navigation.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {
+  NavigationContainer,
+  createNavigationContainerRef,
+} from '@react-navigation/native';
+import { StatusBar } from 'react-native';
+import { useTheme } from './shared/context/themeContext';
+
+export type RootStackParamList = {};
+
+const navigationRef = createNavigationContainerRef<RootStackParamList>();
+
+export const Navigation = () => {
+  const { isDarkMode } = useTheme();
+  return (
+    <NavigationContainer ref={navigationRef}>
+      <StatusBar
+        barStyle={isDarkMode ? 'light-content' : 'dark-content'}
+        translucent
+      />
+    </NavigationContainer>
+  );
+};

--- a/src/navigation.tsx
+++ b/src/navigation.tsx
@@ -1,12 +1,20 @@
 import React from 'react';
 import {
   NavigationContainer,
+  NavigatorScreenParams,
   createNavigationContainerRef,
 } from '@react-navigation/native';
 import { StatusBar } from 'react-native';
 import { useTheme } from './shared/context/themeContext';
+import { ReceiveStackParamList } from './main/home/receive/ReceiveStack';
+import { SendStackParamList } from './main/home/send/SendStack';
 
-export type RootStackParamList = {};
+export type RootStackParamList = {
+  Onboarding: undefined;
+  Main: undefined;
+  ReceiveStack: NavigatorScreenParams<ReceiveStackParamList>;
+  SendStack: NavigatorScreenParams<SendStackParamList>;
+};
 
 const navigationRef = createNavigationContainerRef<RootStackParamList>();
 

--- a/src/navigation.tsx
+++ b/src/navigation.tsx
@@ -28,6 +28,7 @@ export type RootStackParamList = {
 const navigationRef = createNavigationContainerRef<RootStackParamList>();
 const Stack = createStackNavigator<RootStackParamList>();
 
+// TODO: refactor to handle app state via context
 interface NavigationProps {
   onboarded: boolean;
 }

--- a/src/navigation.tsx
+++ b/src/navigation.tsx
@@ -7,6 +7,8 @@ import {
 } from '@react-navigation/native';
 import {
   createStackNavigator,
+  StackNavigationProp,
+  StackScreenProps,
   TransitionPresets,
 } from '@react-navigation/stack';
 
@@ -24,6 +26,12 @@ export type RootStackParamList = {
   ReceiveStack: NavigatorScreenParams<ReceiveStackParamList>;
   SendStack: NavigatorScreenParams<SendStackParamList>;
 };
+
+export type RootStackNavigationProps<Route extends keyof RootStackParamList> =
+  StackNavigationProp<RootStackParamList, Route>;
+
+export type RootStackScreenProps<Route extends keyof RootStackParamList> =
+  StackScreenProps<RootStackParamList, Route>;
 
 const navigationRef = createNavigationContainerRef<RootStackParamList>();
 const Stack = createStackNavigator<RootStackParamList>();

--- a/src/navigation.tsx
+++ b/src/navigation.tsx
@@ -28,6 +28,8 @@ export type RootStackParamList = {
 const navigationRef = createNavigationContainerRef<RootStackParamList>();
 const Stack = createStackNavigator<RootStackParamList>();
 
+export const goHome = () => navigationRef.current?.navigate('Main');
+
 // TODO: refactor to handle app state via context
 interface NavigationProps {
   onboarded: boolean;

--- a/src/navigation.tsx
+++ b/src/navigation.tsx
@@ -1,13 +1,22 @@
 import React from 'react';
+import { StatusBar } from 'react-native';
 import {
   NavigationContainer,
   NavigatorScreenParams,
   createNavigationContainerRef,
 } from '@react-navigation/native';
-import { StatusBar } from 'react-native';
+import {
+  createStackNavigator,
+  TransitionPresets,
+} from '@react-navigation/stack';
+
 import { useTheme } from './shared/context/themeContext';
-import { ReceiveStackParamList } from './main/home/receive/ReceiveStack';
-import { SendStackParamList } from './main/home/send/SendStack';
+import ReceiveStack, {
+  ReceiveStackParamList,
+} from './main/home/receive/ReceiveStack';
+import SendStack, { SendStackParamList } from './main/home/send/SendStack';
+import MainStack from './main/MainStack';
+import OnboardingStack from './onboarding/OnboardingStack';
 
 export type RootStackParamList = {
   Onboarding: undefined;
@@ -17,8 +26,13 @@ export type RootStackParamList = {
 };
 
 const navigationRef = createNavigationContainerRef<RootStackParamList>();
+const Stack = createStackNavigator<RootStackParamList>();
 
-export const Navigation = () => {
+interface NavigationProps {
+  onboarded: boolean;
+}
+
+export const Navigation = ({ onboarded }: NavigationProps) => {
   const { isDarkMode } = useTheme();
   return (
     <NavigationContainer ref={navigationRef}>
@@ -26,6 +40,47 @@ export const Navigation = () => {
         barStyle={isDarkMode ? 'light-content' : 'dark-content'}
         translucent
       />
+      <AppNavigator onboarded={onboarded} />
     </NavigationContainer>
+  );
+};
+
+const AppNavigator = ({ onboarded }: NavigationProps) => {
+  return (
+    <Stack.Navigator
+      initialRouteName={onboarded ? 'Main' : 'Onboarding'}
+      screenOptions={{ headerShown: false }}
+    >
+      <Stack.Screen
+        name="Onboarding"
+        component={OnboardingStack}
+        options={{
+          ...TransitionPresets.ModalPresentationIOS,
+          title: 'onboarding',
+        }}
+      />
+      <Stack.Screen
+        name="Main"
+        component={MainStack}
+        options={{
+          gestureEnabled: false,
+          title: 'Main',
+        }}
+      />
+      <Stack.Screen
+        name="ReceiveStack"
+        component={ReceiveStack}
+        options={{
+          title: 'ReceiveStack',
+        }}
+      />
+      <Stack.Screen
+        name="SendStack"
+        component={SendStack}
+        options={{
+          title: 'SendStack',
+        }}
+      />
+    </Stack.Navigator>
   );
 };

--- a/src/shared/navigation/index.tsx
+++ b/src/shared/navigation/index.tsx
@@ -3,7 +3,6 @@ import { StatusBar } from 'react-native';
 import {
   NavigationContainer,
   NavigatorScreenParams,
-  createNavigationContainerRef,
 } from '@react-navigation/native';
 import {
   createStackNavigator,
@@ -20,6 +19,7 @@ import MainStack from 'src/main/MainStack';
 import OnboardingStack from 'src/onboarding/OnboardingStack';
 
 import { useTheme } from '../context/themeContext';
+import { navigationRef } from './utils';
 
 export type RootStackParamList = {
   Onboarding: undefined;
@@ -34,10 +34,7 @@ export type RootStackNavigationProps<Route extends keyof RootStackParamList> =
 export type RootStackScreenProps<Route extends keyof RootStackParamList> =
   StackScreenProps<RootStackParamList, Route>;
 
-const navigationRef = createNavigationContainerRef<RootStackParamList>();
 const Stack = createStackNavigator<RootStackParamList>();
-
-export const goHome = () => navigationRef.current?.navigate('Main');
 
 // TODO: refactor to handle app state via context
 interface NavigationProps {

--- a/src/shared/navigation/index.tsx
+++ b/src/shared/navigation/index.tsx
@@ -12,13 +12,14 @@ import {
   TransitionPresets,
 } from '@react-navigation/stack';
 
-import { useTheme } from './shared/context/themeContext';
 import ReceiveStack, {
   ReceiveStackParamList,
-} from './main/home/receive/ReceiveStack';
-import SendStack, { SendStackParamList } from './main/home/send/SendStack';
-import MainStack from './main/MainStack';
-import OnboardingStack from './onboarding/OnboardingStack';
+} from 'src/main/home/receive/ReceiveStack';
+import SendStack, { SendStackParamList } from 'src/main/home/send/SendStack';
+import MainStack from 'src/main/MainStack';
+import OnboardingStack from 'src/onboarding/OnboardingStack';
+
+import { useTheme } from '../context/themeContext';
 
 export type RootStackParamList = {
   Onboarding: undefined;

--- a/src/shared/navigation/utils.ts
+++ b/src/shared/navigation/utils.ts
@@ -1,0 +1,7 @@
+import { createNavigationContainerRef } from '@react-navigation/native';
+
+import { RootStackParamList } from '.';
+
+export const navigationRef = createNavigationContainerRef<RootStackParamList>();
+
+export const goHome = () => navigationRef.current?.navigate('Main');


### PR DESCRIPTION
## Description

Currently, app's root navigation was defined on `App.tsx`. Despite not being yet an issue (due to the low amount of stacks and screens on it), further development of the navigation would entangle the code and make it harder to read and maintain.

This PR moves root navigation's code into a separated file and adds some helpers to improve ease of use. Helpers are:
- `RootStackNavigationProps` type
- `RootStackScreenProps` type
- `goHome` fx

Types are useful when defining screen components or navigations since it simply requires the screen's name to be used (and we do not need to define it ourselves on our screen).

Regarding the `goHome` util, it's a simple function that uses RootStack's navigation ref to navigate back to main. On this PR, we use it for the end of the receive flow which by pressing the `Continue` button it redirects back to the home. Prior to this change, it was not trivial to browse back to main.

Lastly, with this PR we fixed native navigation and now it works as expected:
- For iOS devices, swiping from left to right should go to previous screen (as nav icon does).
  - That means that for the QR Screen it should go to AmountInput and not to the previous stack (MainScreen)
- For Android devices, back button should behave as the navigation icon does.  

## Related links

- Closes #102

## Demo

| _iOS_ | _Android_ |
| :---: | :---: |
| <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/7f025534-0b18-4dd2-8c92-c560d6017150' width=400> |  <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/0942189b-8085-4f1f-8771-5c9dc9c9d734' width=400> | 