### PR TITLE
feat: init export flow

### DIFF
--- a/src/main/MainStack.tsx
+++ b/src/main/MainStack.tsx
@@ -19,11 +19,11 @@ import HomeScreen from './home/HomeScreen';
 import WalletScreen from './wallet/WalletScreen';
 
 type MainTabStackParamList = {
-  Wallet: any;
-  Exchange: any;
-  Home: any;
-  Earn: any;
-  Setting: any;
+  Wallet: undefined;
+  Exchange: undefined;
+  Home: undefined;
+  Earn: undefined;
+  Setting: undefined;
 };
 
 export type MainTabStackNavigationProp<

--- a/src/main/MainStack.tsx
+++ b/src/main/MainStack.tsx
@@ -1,6 +1,10 @@
 /* eslint-disable react/no-unstable-nested-components */
 import React from 'react';
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import {
+  BottomTabNavigationProp,
+  BottomTabScreenProps,
+  createBottomTabNavigator,
+} from '@react-navigation/bottom-tabs';
 import { useColorScheme } from 'react-native';
 import { default as Icon } from 'react-native-vector-icons/FontAwesome';
 import { default as AntIcon } from 'react-native-vector-icons/AntDesign';
@@ -21,6 +25,14 @@ type MainTabStackParamList = {
   Earn: any;
   Setting: any;
 };
+
+export type MainTabStackNavigationProp<
+  Route extends keyof MainTabStackParamList,
+> = BottomTabNavigationProp<MainTabStackParamList, Route>;
+
+export type MainTabStackScreenProps<Route extends keyof MainTabStackParamList> =
+  BottomTabScreenProps<MainTabStackParamList, Route>;
+
 const Tab = createBottomTabNavigator<MainTabStackParamList>();
 
 const MainStack = () => {

--- a/src/main/MainStack.tsx
+++ b/src/main/MainStack.tsx
@@ -18,7 +18,7 @@ import SettingScreen from './settings/SettingScreen';
 import HomeScreen from './home/HomeScreen';
 import WalletScreen from './wallet/WalletScreen';
 
-type MainTabStackParamList = {
+export type MainTabStackParamList = {
   Wallet: undefined;
   Exchange: undefined;
   Home: undefined;

--- a/src/main/MainStack.tsx
+++ b/src/main/MainStack.tsx
@@ -5,11 +5,11 @@ import {
   BottomTabScreenProps,
   createBottomTabNavigator,
 } from '@react-navigation/bottom-tabs';
-import { useColorScheme } from 'react-native';
 import { default as Icon } from 'react-native-vector-icons/FontAwesome';
 import { default as AntIcon } from 'react-native-vector-icons/AntDesign';
 import { default as MaterialIcon } from 'react-native-vector-icons/MaterialIcons';
 
+import { useTheme } from 'src/shared/context/themeContext';
 import { styledColors } from 'src/shared/styles';
 
 import ExchangeScreen from './exchange/ExchangeScreen';
@@ -36,7 +36,8 @@ export type MainTabStackScreenProps<Route extends keyof MainTabStackParamList> =
 const Tab = createBottomTabNavigator<MainTabStackParamList>();
 
 const MainStack = () => {
-  const isDarkMode = useColorScheme() === 'dark';
+  const { isDarkMode, theme } = useTheme();
+
   return (
     <Tab.Navigator
       initialRouteName="Home"
@@ -56,12 +57,8 @@ const MainStack = () => {
           } else {
           }
         },
-        tabBarActiveTintColor: isDarkMode
-          ? styledColors.white
-          : styledColors.black,
-        tabBarInactiveTintColor: isDarkMode
-          ? styledColors.white
-          : styledColors.black,
+        tabBarActiveTintColor: theme.primary,
+        tabBarInactiveTintColor: theme.primary,
         tabBarActiveBackgroundColor: isDarkMode
           ? styledColors.dark
           : styledColors.lightGray,

--- a/src/main/MainStack.tsx
+++ b/src/main/MainStack.tsx
@@ -14,7 +14,7 @@ import { styledColors } from 'src/shared/styles';
 
 import ExchangeScreen from './exchange/ExchangeScreen';
 import EarnScreen from './earn/EarnScreen';
-import SettingScreen from './settings/SettingScreen';
+import SettingsScreen from './settings/SettingsScreen';
 import HomeScreen from './home/HomeScreen';
 import WalletScreen from './wallet/WalletScreen';
 
@@ -23,7 +23,7 @@ export type MainTabStackParamList = {
   Exchange: undefined;
   Home: undefined;
   Earn: undefined;
-  Setting: undefined;
+  Settings: undefined;
 };
 
 export type MainTabStackNavigationProp<
@@ -52,7 +52,7 @@ const MainStack = () => {
             return <AntIcon name="home" size={size} color={color} />;
           } else if (route.name === 'Earn') {
             return <Icon name="dollar" size={size} color={color} />;
-          } else if (route.name === 'Setting') {
+          } else if (route.name === 'Settings') {
             return <AntIcon name="setting" size={size} color={color} />;
           } else {
           }
@@ -72,7 +72,7 @@ const MainStack = () => {
       <Tab.Screen name="Exchange" component={ExchangeScreen} />
       <Tab.Screen name="Home" component={HomeScreen} />
       <Tab.Screen name="Earn" component={EarnScreen} />
-      <Tab.Screen name="Setting" component={SettingScreen} />
+      <Tab.Screen name="Settings" component={SettingsScreen} />
     </Tab.Navigator>
   );
 };

--- a/src/main/earn/EarnScreen.tsx
+++ b/src/main/earn/EarnScreen.tsx
@@ -10,11 +10,9 @@ import {
 
 import { styledColors } from 'src/shared/styles';
 
-type EarnScreenProps = {
-  navigation: any;
-};
+import { MainTabStackScreenProps } from '../MainStack';
 
-function EarnScreen({}: EarnScreenProps) {
+const EarnScreen: React.FC<MainTabStackScreenProps<'Earn'>> = ({}) => {
   const isDarkMode = useColorScheme() === 'dark';
 
   const backgroundStyle = {
@@ -43,7 +41,7 @@ function EarnScreen({}: EarnScreenProps) {
       </View>
     </SafeAreaView>
   );
-}
+};
 
 const styles = StyleSheet.create({
   switchStyle: {},

--- a/src/main/exchange/ExchangeScreen.tsx
+++ b/src/main/exchange/ExchangeScreen.tsx
@@ -10,11 +10,9 @@ import {
 
 import { styledColors } from 'src/shared/styles';
 
-type ExchangeScreenProps = {
-  navigation: any;
-};
+import { MainTabStackScreenProps } from '../MainStack';
 
-function ExchangeScreen({}: ExchangeScreenProps) {
+const ExchangeScreen: React.FC<MainTabStackScreenProps<'Exchange'>> = ({}) => {
   const isDarkMode = useColorScheme() === 'dark';
 
   const backgroundStyle = {
@@ -43,7 +41,7 @@ function ExchangeScreen({}: ExchangeScreenProps) {
       </View>
     </SafeAreaView>
   );
-}
+};
 
 const styles = StyleSheet.create({
   switchStyle: {},

--- a/src/main/home/HomeScreen.tsx
+++ b/src/main/home/HomeScreen.tsx
@@ -9,18 +9,18 @@ import {
 import { useTranslation } from 'react-i18next';
 import SwitchSelector from 'react-native-switch-selector';
 
-import { RootStackNavigationProps } from 'src/shared/navigation';
 import { fontStyle, styledColors } from 'src/shared/styles';
 
 import SendStack from './send/SendStack';
 import { ReceiveScreen } from './receive/ReceiveScreen/';
+import { MainTabStackScreenProps } from '../MainStack';
 
 enum SwitchValue {
   Receive = 0,
   Send = 1,
 }
 
-const HomeScreen: React.FC<RootStackNavigationProps<'Main'>> = ({}) => {
+const HomeScreen: React.FC<MainTabStackScreenProps<'Home'>> = ({}) => {
   const { t } = useTranslation();
   const isDarkMode = useColorScheme() === 'dark';
   const [switchValue, setSwitchValue] = useState<SwitchValue>(

--- a/src/main/home/receive/ReceiveQRScreen/index.tsx
+++ b/src/main/home/receive/ReceiveQRScreen/index.tsx
@@ -14,7 +14,7 @@ import { QuaiPayContent } from 'src/shared/components';
 import { fontStyle, styledColors } from 'src/shared/styles';
 import { useProfilePicture, useUsername } from 'src/shared/hooks';
 import ExchangeIcon from 'src/shared/assets/exchange.svg';
-import { goHome } from 'src/shared/navigation/utils';
+import { RootNavigator } from 'src/shared/navigation/utils';
 import { Currency } from 'src/shared/types';
 import { EXCHANGE_RATE } from 'src/shared/constants/exchangeRate';
 
@@ -121,7 +121,10 @@ export const ReceiveQRScreen: React.FC<
             <Text style={styles.learnMoreText}>Learn more about QuaiPay</Text>
           </TouchableOpacity>
         </View>
-        <TouchableOpacity style={styles.completeButton} onPress={goHome}>
+        <TouchableOpacity
+          style={styles.completeButton}
+          onPress={RootNavigator.goHome}
+        >
           <Text style={{ color: styledColors.white }}>
             {t('receive.qrScreen.complete')}
           </Text>

--- a/src/main/settings/SettingScreen.tsx
+++ b/src/main/settings/SettingScreen.tsx
@@ -10,11 +10,9 @@ import {
 
 import { styledColors } from 'src/shared/styles';
 
-type SettingScreenProps = {
-  navigation: any;
-};
+import { MainTabStackScreenProps } from '../MainStack';
 
-function SettingScreen({}: SettingScreenProps) {
+const SettingScreen: React.FC<MainTabStackScreenProps<'Setting'>> = () => {
   const isDarkMode = useColorScheme() === 'dark';
 
   const backgroundStyle = {
@@ -43,7 +41,7 @@ function SettingScreen({}: SettingScreenProps) {
       </View>
     </SafeAreaView>
   );
-}
+};
 
 const styles = StyleSheet.create({
   switchStyle: {},

--- a/src/main/settings/SettingScreen.tsx
+++ b/src/main/settings/SettingScreen.tsx
@@ -1,50 +1,23 @@
 import React from 'react';
-import {
-  SafeAreaView,
-  StatusBar,
-  StyleSheet,
-  Text,
-  View,
-  useColorScheme,
-} from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
-import { styledColors } from 'src/shared/styles';
-
+import { QuaiPayContent } from 'src/shared/components';
 import { MainTabStackScreenProps } from '../MainStack';
 
 const SettingScreen: React.FC<MainTabStackScreenProps<'Setting'>> = () => {
-  const isDarkMode = useColorScheme() === 'dark';
-
-  const backgroundStyle = {
-    backgroundColor: isDarkMode ? styledColors.black : styledColors.white,
-    width: '100%',
-    height: '100%',
-  };
-
-  const topViewStyle = {
-    backgroundColor: isDarkMode ? styledColors.black : styledColors.white,
-    marginLeft: 10,
-    marginRight: 10,
-    marginTop: 'auto',
-    marginBottom: 'auto',
-  };
   return (
-    <SafeAreaView style={backgroundStyle}>
-      <StatusBar
-        barStyle={isDarkMode ? 'light-content' : 'dark-content'}
-        backgroundColor={backgroundStyle.backgroundColor}
-      />
-      <View style={topViewStyle}>
-        <View style={styles.switchStyle}>
-          <Text>Setting Screen</Text>
-        </View>
-      </View>
-    </SafeAreaView>
+    <QuaiPayContent title={'Settings'} navButton={false}>
+      <View style={styles.container} />
+    </QuaiPayContent>
   );
 };
 
 const styles = StyleSheet.create({
-  switchStyle: {},
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
 });
 
 export default SettingScreen;

--- a/src/main/settings/SettingScreen.tsx
+++ b/src/main/settings/SettingScreen.tsx
@@ -1,23 +1,44 @@
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Pressable, StyleSheet, View } from 'react-native';
 
-import { QuaiPayContent } from 'src/shared/components';
+import { QuaiPayContent, QuaiPayText } from 'src/shared/components';
 import { MainTabStackScreenProps } from '../MainStack';
+import { useThemedStyle } from 'src/shared/hooks/useThemedStyle';
+import { Theme } from 'src/shared/types';
 
-const SettingScreen: React.FC<MainTabStackScreenProps<'Setting'>> = () => {
+const SettingScreen: React.FC<MainTabStackScreenProps<'Setting'>> = ({}) => {
+  const styles = useThemedStyle(themedStyles);
+
+  const goToExport = () => true;
+
   return (
     <QuaiPayContent title={'Settings'} navButton={false}>
-      <View style={styles.container} />
+      <View style={styles.container}>
+        <Pressable
+          onPress={goToExport}
+          style={({ pressed }) => [
+            styles.placeholderBtn,
+            pressed && { opacity: 0.5 },
+          ]}
+        >
+          <QuaiPayText type="H3">Export Account</QuaiPayText>
+        </Pressable>
+      </View>
     </QuaiPayContent>
   );
 };
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});
+const themedStyles = (theme: Theme) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    placeholderBtn: {
+      padding: 10,
+      backgroundColor: theme.normal,
+    },
+  });
 
 export default SettingScreen;

--- a/src/main/settings/SettingScreen.tsx
+++ b/src/main/settings/SettingScreen.tsx
@@ -5,11 +5,15 @@ import { QuaiPayContent, QuaiPayText } from 'src/shared/components';
 import { MainTabStackScreenProps } from '../MainStack';
 import { useThemedStyle } from 'src/shared/hooks/useThemedStyle';
 import { Theme } from 'src/shared/types';
+import { useNavigation } from '@react-navigation/native';
+import { RootStackNavigationProps } from 'src/shared/navigation';
 
-const SettingScreen: React.FC<MainTabStackScreenProps<'Setting'>> = ({}) => {
+const SettingScreen: React.FC<MainTabStackScreenProps<'Setting'>> = () => {
+  const navigation = useNavigation<RootStackNavigationProps<'Main'>>();
   const styles = useThemedStyle(themedStyles);
 
-  const goToExport = () => true;
+  const goToExport = () =>
+    navigation.navigate('ExportStack', { screen: 'ExportLanding' });
 
   return (
     <QuaiPayContent title={'Settings'} navButton={false}>

--- a/src/main/settings/SettingsScreen.tsx
+++ b/src/main/settings/SettingsScreen.tsx
@@ -8,7 +8,7 @@ import { Theme } from 'src/shared/types';
 import { useNavigation } from '@react-navigation/native';
 import { RootStackNavigationProps } from 'src/shared/navigation';
 
-const SettingScreen: React.FC<MainTabStackScreenProps<'Setting'>> = () => {
+const SettingsScreen: React.FC<MainTabStackScreenProps<'Settings'>> = () => {
   const navigation = useNavigation<RootStackNavigationProps<'Main'>>();
   const styles = useThemedStyle(themedStyles);
 
@@ -45,4 +45,4 @@ const themedStyles = (theme: Theme) =>
     },
   });
 
-export default SettingScreen;
+export default SettingsScreen;

--- a/src/main/settings/export/ExportCheckoutScreen.tsx
+++ b/src/main/settings/export/ExportCheckoutScreen.tsx
@@ -7,28 +7,38 @@ import { Theme } from 'src/shared/types';
 import { useThemedStyle } from 'src/shared/hooks/useThemedStyle';
 
 import { ExportStackScreenProps } from './ExportStack';
+import { RootNavigator } from 'src/shared/navigation/utils';
 
-export const ExportConfirmationPhraseScreen: React.FC<
-  ExportStackScreenProps<'ExportConfirmationPhrase'>
+export const ExportCheckoutScreen: React.FC<
+  ExportStackScreenProps<'ExportCheckout'>
 > = ({ navigation }) => {
   const { t } = useTranslation();
   const styles = useThemedStyle(themedStyle);
 
-  const goToCheckout = () => navigation.navigate('ExportCheckout');
+  const goToSeedPhraseScreen = () => navigation.navigate('ExportPhrase');
+  const goToSettings = () =>
+    RootNavigator.navigate('Main', { screen: 'Setting' });
 
   return (
     <QuaiPayContent>
       <View style={styles.textContainer}>
-        <QuaiPayText type="H1">Confirm your seed phrase</QuaiPayText>
+        <QuaiPayText type="H1">Never Share your Recovery Codes</QuaiPayText>
         <QuaiPayText type="H3">Description</QuaiPayText>
       </View>
       <View style={styles.separator} />
       <Pressable
-        onPress={goToCheckout}
+        onPress={goToSeedPhraseScreen}
         style={({ pressed }) => [
-          styles.continueButton,
+          styles.button,
+          styles.reviewButton,
           pressed && { opacity: 0.5 },
         ]}
+      >
+        <QuaiPayText>Review Seed Phrase</QuaiPayText>
+      </Pressable>
+      <Pressable
+        onPress={goToSettings}
+        style={({ pressed }) => [styles.button, pressed && { opacity: 0.5 }]}
       >
         <QuaiPayText>{t('common.continue')}</QuaiPayText>
       </Pressable>
@@ -43,11 +53,14 @@ const themedStyle = (theme: Theme) =>
       alignItems: 'center',
       marginBottom: 20,
     },
-    continueButton: {
+    button: {
       marginBottom: 70,
       padding: 10,
       marginHorizontal: 30,
       backgroundColor: theme.normal,
+    },
+    reviewButton: {
+      marginBottom: 16,
     },
     separator: {
       flex: 1,

--- a/src/main/settings/export/ExportCheckoutScreen.tsx
+++ b/src/main/settings/export/ExportCheckoutScreen.tsx
@@ -17,7 +17,7 @@ export const ExportCheckoutScreen: React.FC<
 
   const goToSeedPhraseScreen = () => navigation.navigate('ExportPhrase');
   const goToSettings = () =>
-    RootNavigator.navigate('Main', { screen: 'Setting' });
+    RootNavigator.navigate('Main', { screen: 'Settings' });
 
   return (
     <QuaiPayContent>

--- a/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
+++ b/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
@@ -8,24 +8,20 @@ import { useThemedStyle } from 'src/shared/hooks/useThemedStyle';
 
 import { ExportStackScreenProps } from './ExportStack';
 
-export const ExportPhraseScreen: React.FC<
-  ExportStackScreenProps<'ExportPhrase'>
-> = ({ navigation }) => {
+export const ExportConfirmationPhraseScreen: React.FC<
+  ExportStackScreenProps<'ExportConfirmationPhrase'>
+> = ({}) => {
   const { t } = useTranslation();
   const styles = useThemedStyle(themedStyle);
-
-  const goToConfirmPhrase = () =>
-    navigation.navigate('ExportConfirmationPhrase');
 
   return (
     <QuaiPayContent>
       <View style={styles.textContainer}>
-        <QuaiPayText type="H1">Write down your Seed Phrase</QuaiPayText>
+        <QuaiPayText type="H1">Confirm your seed phrase</QuaiPayText>
         <QuaiPayText type="H3">Description</QuaiPayText>
       </View>
       <View style={styles.separator} />
       <Pressable
-        onPress={goToConfirmPhrase}
         style={({ pressed }) => [
           styles.continueButton,
           pressed && { opacity: 0.5 },
@@ -43,7 +39,6 @@ const themedStyle = (theme: Theme) =>
       flex: 1,
       alignItems: 'center',
       marginBottom: 20,
-      marginHorizontal: 20,
     },
     continueButton: {
       marginBottom: 70,

--- a/src/main/settings/export/ExportLandingScreen.tsx
+++ b/src/main/settings/export/ExportLandingScreen.tsx
@@ -1,16 +1,57 @@
 import React from 'react';
-import { View } from 'react-native';
+import { Pressable, StyleSheet, View } from 'react-native';
 
-import { QuaiPayContent } from 'src/shared/components';
+import { QuaiPayContent, QuaiPayText } from 'src/shared/components';
+import { Theme } from 'src/shared/types';
+import { useThemedStyle } from 'src/shared/hooks/useThemedStyle';
 
 import { ExportStackScreenProps } from './ExportStack';
 
+// TODO: move copy to i18n
+// TODO: tweak UI to match L&F
 export const ExportLandingScreen: React.FC<
   ExportStackScreenProps<'ExportLanding'>
 > = ({}) => {
+  const styles = useThemedStyle(themedStyle);
   return (
     <QuaiPayContent>
-      <View />
+      <View style={styles.textContainer}>
+        <QuaiPayText type="H1">Setup Account Recovery</QuaiPayText>
+        <QuaiPayText type="H3">Description</QuaiPayText>
+      </View>
+      <Pressable
+        style={({ pressed }) => [styles.card, pressed && { opacity: 0.5 }]}
+      >
+        <QuaiPayText>Set up Seed Phrase</QuaiPayText>
+      </Pressable>
+      <Pressable
+        style={({ pressed }) => [styles.card, pressed && { opacity: 0.5 }]}
+      >
+        <QuaiPayText>Account Recovery QR Code</QuaiPayText>
+      </Pressable>
+      <View style={styles.separator} />
+      <QuaiPayText style={styles.learnMore}>Learn more</QuaiPayText>
     </QuaiPayContent>
   );
 };
+
+const themedStyle = (theme: Theme) =>
+  StyleSheet.create({
+    textContainer: {
+      flex: 1,
+      alignItems: 'center',
+      marginBottom: 20,
+    },
+    card: {
+      backgroundColor: theme.secondary,
+      marginBottom: 12,
+      padding: 10,
+      marginHorizontal: 32,
+    },
+    learnMore: {
+      marginBottom: 70,
+    },
+    separator: {
+      flex: 1,
+    },
+  });

--- a/src/main/settings/export/ExportLandingScreen.tsx
+++ b/src/main/settings/export/ExportLandingScreen.tsx
@@ -13,8 +13,15 @@ export const ExportLandingScreen: React.FC<
   ExportStackScreenProps<'ExportLanding'>
 > = ({ navigation }) => {
   const styles = useThemedStyle(themedStyle);
+  // TODO: check if seed phrase was already generated
+  const hasSeedPhraseAlready = true;
 
   const goToSetupSeedPhrase = () => navigation.navigate('ExportPhrase');
+  const goToQRCode = () =>
+    hasSeedPhraseAlready
+      ? navigation.navigate('ExportQRCode')
+      : // eslint-disable-next-line no-alert
+        alert('Please setup your seed phrase first');
 
   return (
     <QuaiPayContent>
@@ -29,6 +36,7 @@ export const ExportLandingScreen: React.FC<
         <QuaiPayText>Set up Seed Phrase</QuaiPayText>
       </Pressable>
       <Pressable
+        onPress={goToQRCode}
         style={({ pressed }) => [styles.card, pressed && { opacity: 0.5 }]}
       >
         <QuaiPayText>Account Recovery QR Code</QuaiPayText>

--- a/src/main/settings/export/ExportLandingScreen.tsx
+++ b/src/main/settings/export/ExportLandingScreen.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { View } from 'react-native';
+
+import { QuaiPayContent } from 'src/shared/components';
+
+import { ExportStackScreenProps } from './ExportStack';
+
+export const ExportLandingScreen: React.FC<
+  ExportStackScreenProps<'ExportLanding'>
+> = ({}) => {
+  return (
+    <QuaiPayContent>
+      <View />
+    </QuaiPayContent>
+  );
+};

--- a/src/main/settings/export/ExportLandingScreen.tsx
+++ b/src/main/settings/export/ExportLandingScreen.tsx
@@ -11,8 +11,11 @@ import { ExportStackScreenProps } from './ExportStack';
 // TODO: tweak UI to match L&F
 export const ExportLandingScreen: React.FC<
   ExportStackScreenProps<'ExportLanding'>
-> = ({}) => {
+> = ({ navigation }) => {
   const styles = useThemedStyle(themedStyle);
+
+  const goToSetupSeedPhrase = () => navigation.navigate('ExportPhrase');
+
   return (
     <QuaiPayContent>
       <View style={styles.textContainer}>
@@ -20,6 +23,7 @@ export const ExportLandingScreen: React.FC<
         <QuaiPayText type="H3">Description</QuaiPayText>
       </View>
       <Pressable
+        onPress={goToSetupSeedPhrase}
         style={({ pressed }) => [styles.card, pressed && { opacity: 0.5 }]}
       >
         <QuaiPayText>Set up Seed Phrase</QuaiPayText>

--- a/src/main/settings/export/ExportPhraseScreen.tsx
+++ b/src/main/settings/export/ExportPhraseScreen.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+import { QuaiPayContent, QuaiPayText } from 'src/shared/components';
+import { Theme } from 'src/shared/types';
+import { useThemedStyle } from 'src/shared/hooks/useThemedStyle';
+
+import { ExportStackScreenProps } from './ExportStack';
+
+export const ExportPhraseScreen: React.FC<
+  ExportStackScreenProps<'ExportPhrase'>
+> = ({}) => {
+  const { t } = useTranslation();
+  const styles = useThemedStyle(themedStyle);
+
+  return (
+    <QuaiPayContent>
+      <View style={styles.textContainer}>
+        <QuaiPayText type="H1">Write down your Seed Phrase</QuaiPayText>
+        <QuaiPayText type="H3">Description</QuaiPayText>
+      </View>
+      <View style={styles.separator} />
+      <Pressable
+        style={({ pressed }) => [
+          styles.continueButton,
+          pressed && { opacity: 0.5 },
+        ]}
+      >
+        <QuaiPayText>{t('common.continue')}</QuaiPayText>
+      </Pressable>
+    </QuaiPayContent>
+  );
+};
+
+const themedStyle = (theme: Theme) =>
+  StyleSheet.create({
+    textContainer: {
+      flex: 1,
+      alignItems: 'center',
+      marginBottom: 20,
+      marginHorizontal: 20,
+    },
+    continueButton: {
+      marginBottom: 70,
+      padding: 10,
+      marginHorizontal: 30,
+      backgroundColor: theme.normal,
+    },
+    separator: {
+      flex: 1,
+    },
+  });

--- a/src/main/settings/export/ExportQRCode.tsx
+++ b/src/main/settings/export/ExportQRCode.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+
+import { QuaiPayContent, QuaiPayText } from 'src/shared/components';
+import { Theme } from 'src/shared/types';
+import { useThemedStyle } from 'src/shared/hooks/useThemedStyle';
+
+import { ExportStackScreenProps } from './ExportStack';
+import { RootNavigator } from 'src/shared/navigation/utils';
+
+export const ExportQRCodeScreen: React.FC<
+  ExportStackScreenProps<'ExportQRCode'>
+> = ({}) => {
+  const styles = useThemedStyle(themedStyle);
+
+  // TODO: define what action should be made here
+  const handleExportButton = () => false;
+  const goToSettings = () =>
+    RootNavigator.navigate('Main', { screen: 'Setting' });
+
+  return (
+    <QuaiPayContent>
+      <View style={styles.separator} />
+      <View style={styles.flexContainer}>
+        <View style={styles.cardContainer}>
+          <QuaiPayText type="H1">Recovery QR Code</QuaiPayText>
+          <QuaiPayText type="H3">Description</QuaiPayText>
+        </View>
+        <QuaiPayText>Learn more</QuaiPayText>
+      </View>
+      <View style={styles.separator} />
+      <Pressable
+        onPress={handleExportButton}
+        style={({ pressed }) => [
+          styles.button,
+          styles.reviewButton,
+          pressed && { opacity: 0.5 },
+        ]}
+      >
+        <QuaiPayText>Export</QuaiPayText>
+      </Pressable>
+      <Pressable
+        onPress={goToSettings}
+        style={({ pressed }) => [styles.button, pressed && { opacity: 0.5 }]}
+      >
+        <QuaiPayText>Complete</QuaiPayText>
+      </Pressable>
+    </QuaiPayContent>
+  );
+};
+
+const themedStyle = (theme: Theme) =>
+  StyleSheet.create({
+    flexContainer: {
+      flex: 1,
+    },
+    cardContainer: {
+      flex: 1,
+      alignItems: 'center',
+      marginHorizontal: 16,
+      marginBottom: 20,
+      paddingHorizontal: 32,
+      backgroundColor: theme.secondary,
+    },
+    button: {
+      marginBottom: 70,
+      padding: 10,
+      marginHorizontal: 30,
+      backgroundColor: theme.normal,
+    },
+    reviewButton: {
+      marginBottom: 16,
+    },
+    separator: {
+      flex: 1,
+    },
+  });

--- a/src/main/settings/export/ExportQRCode.tsx
+++ b/src/main/settings/export/ExportQRCode.tsx
@@ -16,7 +16,7 @@ export const ExportQRCodeScreen: React.FC<
   // TODO: define what action should be made here
   const handleExportButton = () => false;
   const goToSettings = () =>
-    RootNavigator.navigate('Main', { screen: 'Setting' });
+    RootNavigator.navigate('Main', { screen: 'Settings' });
 
   return (
     <QuaiPayContent>

--- a/src/main/settings/export/ExportStack.tsx
+++ b/src/main/settings/export/ExportStack.tsx
@@ -6,9 +6,11 @@ import {
 } from '@react-navigation/stack';
 
 import { ExportLandingScreen } from './ExportLandingScreen';
+import { ExportPhraseScreen } from './ExportPhraseScreen';
 
 export type ExportStackParamList = {
   ExportLanding: undefined;
+  ExportPhrase: undefined;
 };
 
 export type ExportStackScreenProps<Route extends keyof ExportStackParamList> =
@@ -27,6 +29,7 @@ const ExportStack = () => {
       screenOptions={{ headerShown: false }}
     >
       <Stack.Screen name="ExportLanding" component={ExportLandingScreen} />
+      <Stack.Screen name="ExportPhrase" component={ExportPhraseScreen} />
     </Stack.Navigator>
   );
 };

--- a/src/main/settings/export/ExportStack.tsx
+++ b/src/main/settings/export/ExportStack.tsx
@@ -8,11 +8,13 @@ import {
 import { ExportLandingScreen } from './ExportLandingScreen';
 import { ExportPhraseScreen } from './ExportPhraseScreen';
 import { ExportConfirmationPhraseScreen } from './ExportConfirmationPhraseScreen';
+import { ExportCheckoutScreen } from './ExportCheckoutScreen';
 
 export type ExportStackParamList = {
   ExportLanding: undefined;
   ExportPhrase: undefined;
   ExportConfirmationPhrase: undefined;
+  ExportCheckout: undefined;
 };
 
 export type ExportStackScreenProps<Route extends keyof ExportStackParamList> =
@@ -36,6 +38,7 @@ const ExportStack = () => {
         name="ExportConfirmationPhrase"
         component={ExportConfirmationPhraseScreen}
       />
+      <Stack.Screen name="ExportCheckout" component={ExportCheckoutScreen} />
     </Stack.Navigator>
   );
 };

--- a/src/main/settings/export/ExportStack.tsx
+++ b/src/main/settings/export/ExportStack.tsx
@@ -9,12 +9,14 @@ import { ExportLandingScreen } from './ExportLandingScreen';
 import { ExportPhraseScreen } from './ExportPhraseScreen';
 import { ExportConfirmationPhraseScreen } from './ExportConfirmationPhraseScreen';
 import { ExportCheckoutScreen } from './ExportCheckoutScreen';
+import { ExportQRCodeScreen } from './ExportQRCode';
 
 export type ExportStackParamList = {
   ExportLanding: undefined;
   ExportPhrase: undefined;
   ExportConfirmationPhrase: undefined;
   ExportCheckout: undefined;
+  ExportQRCode: undefined;
 };
 
 export type ExportStackScreenProps<Route extends keyof ExportStackParamList> =
@@ -39,6 +41,7 @@ const ExportStack = () => {
         component={ExportConfirmationPhraseScreen}
       />
       <Stack.Screen name="ExportCheckout" component={ExportCheckoutScreen} />
+      <Stack.Screen name="ExportQRCode" component={ExportQRCodeScreen} />
     </Stack.Navigator>
   );
 };

--- a/src/main/settings/export/ExportStack.tsx
+++ b/src/main/settings/export/ExportStack.tsx
@@ -7,10 +7,12 @@ import {
 
 import { ExportLandingScreen } from './ExportLandingScreen';
 import { ExportPhraseScreen } from './ExportPhraseScreen';
+import { ExportConfirmationPhraseScreen } from './ExportConfirmationPhraseScreen';
 
 export type ExportStackParamList = {
   ExportLanding: undefined;
   ExportPhrase: undefined;
+  ExportConfirmationPhrase: undefined;
 };
 
 export type ExportStackScreenProps<Route extends keyof ExportStackParamList> =
@@ -30,6 +32,10 @@ const ExportStack = () => {
     >
       <Stack.Screen name="ExportLanding" component={ExportLandingScreen} />
       <Stack.Screen name="ExportPhrase" component={ExportPhraseScreen} />
+      <Stack.Screen
+        name="ExportConfirmationPhrase"
+        component={ExportConfirmationPhraseScreen}
+      />
     </Stack.Navigator>
   );
 };

--- a/src/main/settings/export/ExportStack.tsx
+++ b/src/main/settings/export/ExportStack.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import {
+  createStackNavigator,
+  StackScreenProps,
+  StackNavigationProp,
+} from '@react-navigation/stack';
+
+import { ExportLandingScreen } from './ExportLandingScreen';
+
+export type ExportStackParamList = {
+  ExportLanding: undefined;
+};
+
+export type ExportStackScreenProps<Route extends keyof ExportStackParamList> =
+  StackScreenProps<ExportStackParamList, Route>;
+
+export type ExportStackNavigationProps<
+  Route extends keyof ExportStackParamList,
+> = StackNavigationProp<ExportStackParamList, Route>;
+
+const Stack = createStackNavigator<ExportStackParamList>();
+
+const ExportStack = () => {
+  return (
+    <Stack.Navigator
+      initialRouteName="ExportLanding"
+      screenOptions={{ headerShown: false }}
+    >
+      <Stack.Screen name="ExportLanding" component={ExportLandingScreen} />
+    </Stack.Navigator>
+  );
+};
+
+export default ExportStack;

--- a/src/main/wallet/WalletScreen.tsx
+++ b/src/main/wallet/WalletScreen.tsx
@@ -10,11 +10,9 @@ import {
 
 import { styledColors } from 'src/shared/styles';
 
-type ExchangeScreenProps = {
-  navigation: any;
-};
+import { MainTabStackScreenProps } from '../MainStack';
 
-function ExchangeScreen({}: ExchangeScreenProps) {
+const WalletScreen: React.FC<MainTabStackScreenProps<'Wallet'>> = ({}) => {
   const isDarkMode = useColorScheme() === 'dark';
 
   const backgroundStyle = {
@@ -43,10 +41,10 @@ function ExchangeScreen({}: ExchangeScreenProps) {
       </View>
     </SafeAreaView>
   );
-}
+};
 
 const styles = StyleSheet.create({
   switchStyle: {},
 });
 
-export default ExchangeScreen;
+export default WalletScreen;

--- a/src/onboarding/screens/SetupLocationScreen.tsx
+++ b/src/onboarding/screens/SetupLocationScreen.tsx
@@ -30,13 +30,14 @@ import { buttonStyle, fontStyle, styledColors } from 'src/shared/styles';
 import { storeItem } from 'src/shared/services/keychain';
 import { keychainKeys } from 'src/shared/constants/keychainKeys';
 import Loader from 'src/shared/Loader';
+import { RootNavigator } from 'src/shared/navigation/utils';
 
 async function getPosition(options?: GeoOptions): Promise<GeoPosition> {
   return new Promise((resolve, reject) =>
     Geolocation.getCurrentPosition(resolve, reject, options),
   );
 }
-function SetupLocationScreen({ navigation }: any) {
+function SetupLocationScreen() {
   const isDarkMode = useColorScheme() === 'dark';
   const [gettingLocation, setGettingLocation] = useState(false);
 
@@ -91,7 +92,7 @@ function SetupLocationScreen({ navigation }: any) {
 
       setGettingLocation(false);
       await AsyncStorage.setItem('onboarded', 'true');
-      navigation.navigate('Main');
+      RootNavigator.goHome();
     }
   }, []);
 

--- a/src/shared/components/QuaiPayContent.tsx
+++ b/src/shared/components/QuaiPayContent.tsx
@@ -87,8 +87,8 @@ const themedStyle = (theme: Theme) =>
       flexDirection: 'row',
       alignItems: 'center',
       paddingHorizontal: 20,
-      paddingTop: 8,
-      paddingBottom: 12,
+      paddingVertical: 8,
+      minHeight: 60,
     },
     navIconMargin: {
       marginRight: MARGIN_RIGHT_OFFSET,

--- a/src/shared/navigation/index.tsx
+++ b/src/shared/navigation/index.tsx
@@ -20,12 +20,16 @@ import OnboardingStack from 'src/onboarding/OnboardingStack';
 
 import { useTheme } from '../context/themeContext';
 import { navigationRef } from './utils';
+import ExportStack, {
+  ExportStackParamList,
+} from 'src/main/settings/export/ExportStack';
 
 export type RootStackParamList = {
   Onboarding: undefined;
   Main: undefined;
   ReceiveStack: NavigatorScreenParams<ReceiveStackParamList>;
   SendStack: NavigatorScreenParams<SendStackParamList>;
+  ExportStack: NavigatorScreenParams<ExportStackParamList>;
 };
 
 export type RootStackNavigationProps<Route extends keyof RootStackParamList> =
@@ -88,6 +92,13 @@ const AppNavigator = ({ onboarded }: NavigationProps) => {
         component={SendStack}
         options={{
           title: 'SendStack',
+        }}
+      />
+      <Stack.Screen
+        name="ExportStack"
+        component={ExportStack}
+        options={{
+          title: 'ExportStack',
         }}
       />
     </Stack.Navigator>

--- a/src/shared/navigation/index.tsx
+++ b/src/shared/navigation/index.tsx
@@ -19,7 +19,7 @@ import MainStack, { MainTabStackParamList } from 'src/main/MainStack';
 import OnboardingStack from 'src/onboarding/OnboardingStack';
 
 import { useTheme } from '../context/themeContext';
-import { navigationRef } from './utils';
+import { RootNavigator } from './utils';
 import ExportStack, {
   ExportStackParamList,
 } from 'src/main/settings/export/ExportStack';
@@ -48,7 +48,7 @@ interface NavigationProps {
 export const Navigation = ({ onboarded }: NavigationProps) => {
   const { isDarkMode } = useTheme();
   return (
-    <NavigationContainer ref={navigationRef}>
+    <NavigationContainer ref={RootNavigator.ref}>
       <StatusBar
         barStyle={isDarkMode ? 'light-content' : 'dark-content'}
         translucent

--- a/src/shared/navigation/index.tsx
+++ b/src/shared/navigation/index.tsx
@@ -15,7 +15,7 @@ import ReceiveStack, {
   ReceiveStackParamList,
 } from 'src/main/home/receive/ReceiveStack';
 import SendStack, { SendStackParamList } from 'src/main/home/send/SendStack';
-import MainStack from 'src/main/MainStack';
+import MainStack, { MainTabStackParamList } from 'src/main/MainStack';
 import OnboardingStack from 'src/onboarding/OnboardingStack';
 
 import { useTheme } from '../context/themeContext';
@@ -26,7 +26,7 @@ import ExportStack, {
 
 export type RootStackParamList = {
   Onboarding: undefined;
-  Main: undefined;
+  Main: NavigatorScreenParams<MainTabStackParamList>;
   ReceiveStack: NavigatorScreenParams<ReceiveStackParamList>;
   SendStack: NavigatorScreenParams<SendStackParamList>;
   ExportStack: NavigatorScreenParams<ExportStackParamList>;

--- a/src/shared/navigation/utils.ts
+++ b/src/shared/navigation/utils.ts
@@ -2,6 +2,12 @@ import { createNavigationContainerRef } from '@react-navigation/native';
 
 import { RootStackParamList } from '.';
 
-export const navigationRef = createNavigationContainerRef<RootStackParamList>();
+const ref = createNavigationContainerRef<RootStackParamList>();
 
-export const goHome = () => navigationRef.current?.navigate('Main');
+const goHome = () => ref.current?.navigate('Main', { screen: 'Home' });
+
+export const RootNavigator = {
+  goHome,
+  navigate: ref?.navigate,
+  ref,
+};


### PR DESCRIPTION
## Description

With this PR, we lay out the navigation for the whole export flow. After this, we shall implement each screen individually and independently (except for any new prop definition needed by the feature).

## Related Links

- Closes #107 

## Demo

| _iOS_ | _Android_ |
| :--: | :--: |
| <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/267cc4a5-b950-4716-8832-1ebbfbd65a42' width=400> | <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/cb578a99-4f98-4d15-ae63-0000e0c6406e' width=400> |