### PR TITLE
feat: add ui and functionality to export phrase confirmation

### DIFF
--- a/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
+++ b/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
@@ -11,12 +11,18 @@ import { styledColors } from 'src/shared/styles';
 
 export const ExportConfirmationPhraseScreen: React.FC<
   ExportStackScreenProps<'ExportConfirmationPhrase'>
-> = ({ navigation }) => {
+> = ({
+  navigation,
+  route: {
+    params: { seedPhrase },
+  },
+}) => {
   const { t } = useTranslation();
   const styles = useThemedStyle(themedStyle);
 
   const goToCheckout = () => navigation.navigate('ExportCheckout');
 
+  const seedPhraseWords = seedPhrase.split(' ');
   return (
     <QuaiPayContent>
       <View style={styles.textContainer}>
@@ -24,6 +30,18 @@ export const ExportConfirmationPhraseScreen: React.FC<
         <QuaiPayText type="H3">
           {t('export.confirmation.description')}
         </QuaiPayText>
+      </View>
+      <View style={styles.wordFillerContainer}>
+        {seedPhraseWords.map((_, idx) => (
+          <View key={idx} style={styles.itemContainer}>
+            <View style={styles.word} />
+          </View>
+        ))}
+        {seedPhraseWords.map((word, idx) => (
+          <View key={idx} style={styles.itemContainer}>
+            <QuaiPayText style={styles.word}>{word}</QuaiPayText>
+          </View>
+        ))}
       </View>
       <View style={styles.separator} />
       <Pressable
@@ -47,6 +65,31 @@ const themedStyle = (theme: Theme) =>
       flex: 1,
       alignItems: 'center',
       marginBottom: 20,
+    },
+    wordFillerContainer: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      justifyContent: 'flex-end',
+      gap: 8,
+      marginHorizontal: 16,
+      paddingRight: 16,
+    },
+    itemContainer: {
+      width: '30%',
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'flex-end',
+      gap: 2,
+    },
+    word: {
+      borderWidth: 1,
+      borderRadius: 4,
+      borderColor: theme.border,
+      paddingTop: 10,
+      paddingHorizontal: 8,
+      width: 85,
+      height: 40,
+      textAlign: 'left',
     },
     continueButton: {
       marginBottom: 70,

--- a/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
+++ b/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
@@ -5,9 +5,10 @@ import { useTranslation } from 'react-i18next';
 import { QuaiPayContent, QuaiPayText } from 'src/shared/components';
 import { Theme } from 'src/shared/types';
 import { useThemedStyle } from 'src/shared/hooks/useThemedStyle';
+import { styledColors } from 'src/shared/styles';
 
 import { ExportStackScreenProps } from './ExportStack';
-import { styledColors } from 'src/shared/styles';
+import { SeedPhraseConfirmation } from './components/SeedPhraseConfirmation';
 
 export const ExportConfirmationPhraseScreen: React.FC<
   ExportStackScreenProps<'ExportConfirmationPhrase'>
@@ -22,7 +23,6 @@ export const ExportConfirmationPhraseScreen: React.FC<
 
   const goToCheckout = () => navigation.navigate('ExportCheckout');
 
-  const seedPhraseWords = seedPhrase.split(' ');
   return (
     <QuaiPayContent>
       <ScrollView>
@@ -32,18 +32,7 @@ export const ExportConfirmationPhraseScreen: React.FC<
             {t('export.confirmation.description')}
           </QuaiPayText>
         </View>
-        <View style={styles.wordFillerContainer}>
-          {seedPhraseWords.map((_, idx) => (
-            <View key={idx} style={styles.itemContainer}>
-              <View style={styles.word} />
-            </View>
-          ))}
-          {seedPhraseWords.map((word, idx) => (
-            <View key={idx} style={styles.itemContainer}>
-              <QuaiPayText style={styles.word}>{word}</QuaiPayText>
-            </View>
-          ))}
-        </View>
+        <SeedPhraseConfirmation seedPhrase={seedPhrase} />
         <View style={styles.separator} />
         <Pressable
           onPress={goToCheckout}
@@ -67,31 +56,7 @@ const themedStyle = (theme: Theme) =>
       flex: 1,
       alignItems: 'center',
       marginBottom: 20,
-    },
-    wordFillerContainer: {
-      flexDirection: 'row',
-      flexWrap: 'wrap',
-      justifyContent: 'flex-end',
-      gap: 8,
-      marginHorizontal: 16,
-      paddingRight: 16,
-    },
-    itemContainer: {
-      width: '30%',
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'flex-end',
-      gap: 2,
-    },
-    word: {
-      borderWidth: 1,
-      borderRadius: 4,
-      borderColor: theme.border,
-      paddingTop: 10,
-      paddingHorizontal: 8,
-      width: 85,
-      height: 40,
-      textAlign: 'left',
+      marginHorizontal: 48,
     },
     continueButton: {
       marginBottom: 70,

--- a/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
+++ b/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
@@ -83,7 +83,7 @@ const themedStyle = (theme: Theme) =>
       backgroundColor: theme.normal,
     },
     separator: {
-      height: 40,
+      height: 86,
     },
     whiteColor: {
       color: styledColors.white,

--- a/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
+++ b/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 
@@ -20,6 +20,12 @@ export const ExportConfirmationPhraseScreen: React.FC<
 }) => {
   const { t } = useTranslation();
   const styles = useThemedStyle(themedStyle);
+  const [proposedSeedPhraseWords, setProposedSeedPhraseWords] = useState<
+    string[]
+  >([]);
+
+  const proposedSeedPhrase = proposedSeedPhraseWords.join(' ');
+  const isPhraseOk = seedPhrase === proposedSeedPhrase;
 
   const goToCheckout = () => navigation.navigate('ExportCheckout');
 
@@ -32,12 +38,18 @@ export const ExportConfirmationPhraseScreen: React.FC<
             {t('export.confirmation.description')}
           </QuaiPayText>
         </View>
-        <SeedPhraseConfirmation seedPhrase={seedPhrase} />
+        <SeedPhraseConfirmation
+          seedPhrase={seedPhrase}
+          result={proposedSeedPhraseWords}
+          setResult={setProposedSeedPhraseWords}
+        />
         <View style={styles.separator} />
         <Pressable
           onPress={goToCheckout}
+          disabled={!isPhraseOk}
           style={({ pressed }) => [
             styles.continueButton,
+            !isPhraseOk && styles.disabledButton,
             pressed && { opacity: 0.5 },
           ]}
         >
@@ -69,5 +81,8 @@ const themedStyle = (theme: Theme) =>
     },
     whiteColor: {
       color: styledColors.white,
+    },
+    disabledButton: {
+      backgroundColor: theme.secondary,
     },
   });

--- a/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
+++ b/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
@@ -20,8 +20,10 @@ export const ExportConfirmationPhraseScreen: React.FC<
   return (
     <QuaiPayContent>
       <View style={styles.textContainer}>
-        <QuaiPayText type="H1">Confirm your seed phrase</QuaiPayText>
-        <QuaiPayText type="H3">Description</QuaiPayText>
+        <QuaiPayText type="H1">{t('export.confirmation.title')}</QuaiPayText>
+        <QuaiPayText type="H3">
+          {t('export.confirmation.description')}
+        </QuaiPayText>
       </View>
       <View style={styles.separator} />
       <Pressable

--- a/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
+++ b/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
@@ -25,8 +25,14 @@ export const ExportConfirmationPhraseScreen: React.FC<
   >([]);
 
   const proposedSeedPhrase = proposedSeedPhraseWords.join(' ');
+  const isPhraseComplete =
+    proposedSeedPhrase.length === seedPhrase.split('').length;
   const isPhraseOk = seedPhrase === proposedSeedPhrase;
 
+  const handleCTAPress = () =>
+    isPhraseOk ? goToCheckout() : popWrongPhraseMessage();
+  const popWrongPhraseMessage = () =>
+    alert(t('export.confirmation.wrongPhraseMessage'));
   const goToCheckout = () => navigation.navigate('ExportCheckout');
 
   return (
@@ -45,8 +51,8 @@ export const ExportConfirmationPhraseScreen: React.FC<
         />
         <View style={styles.separator} />
         <Pressable
-          onPress={goToCheckout}
-          disabled={!isPhraseOk}
+          onPress={handleCTAPress}
+          disabled={!isPhraseComplete}
           style={({ pressed }) => [
             styles.continueButton,
             !isPhraseOk && styles.disabledButton,

--- a/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
+++ b/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Pressable, StyleSheet, View } from 'react-native';
+import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 
 import { QuaiPayContent, QuaiPayText } from 'src/shared/components';
@@ -25,36 +25,38 @@ export const ExportConfirmationPhraseScreen: React.FC<
   const seedPhraseWords = seedPhrase.split(' ');
   return (
     <QuaiPayContent>
-      <View style={styles.textContainer}>
-        <QuaiPayText type="H1">{t('export.confirmation.title')}</QuaiPayText>
-        <QuaiPayText type="H3">
-          {t('export.confirmation.description')}
-        </QuaiPayText>
-      </View>
-      <View style={styles.wordFillerContainer}>
-        {seedPhraseWords.map((_, idx) => (
-          <View key={idx} style={styles.itemContainer}>
-            <View style={styles.word} />
-          </View>
-        ))}
-        {seedPhraseWords.map((word, idx) => (
-          <View key={idx} style={styles.itemContainer}>
-            <QuaiPayText style={styles.word}>{word}</QuaiPayText>
-          </View>
-        ))}
-      </View>
-      <View style={styles.separator} />
-      <Pressable
-        onPress={goToCheckout}
-        style={({ pressed }) => [
-          styles.continueButton,
-          pressed && { opacity: 0.5 },
-        ]}
-      >
-        <QuaiPayText style={styles.whiteColor}>
-          {t('common.continue')}
-        </QuaiPayText>
-      </Pressable>
+      <ScrollView>
+        <View style={styles.textContainer}>
+          <QuaiPayText type="H1">{t('export.confirmation.title')}</QuaiPayText>
+          <QuaiPayText type="H3">
+            {t('export.confirmation.description')}
+          </QuaiPayText>
+        </View>
+        <View style={styles.wordFillerContainer}>
+          {seedPhraseWords.map((_, idx) => (
+            <View key={idx} style={styles.itemContainer}>
+              <View style={styles.word} />
+            </View>
+          ))}
+          {seedPhraseWords.map((word, idx) => (
+            <View key={idx} style={styles.itemContainer}>
+              <QuaiPayText style={styles.word}>{word}</QuaiPayText>
+            </View>
+          ))}
+        </View>
+        <View style={styles.separator} />
+        <Pressable
+          onPress={goToCheckout}
+          style={({ pressed }) => [
+            styles.continueButton,
+            pressed && { opacity: 0.5 },
+          ]}
+        >
+          <QuaiPayText style={styles.whiteColor}>
+            {t('common.continue')}
+          </QuaiPayText>
+        </Pressable>
+      </ScrollView>
     </QuaiPayContent>
   );
 };
@@ -98,7 +100,7 @@ const themedStyle = (theme: Theme) =>
       backgroundColor: theme.normal,
     },
     separator: {
-      flex: 1,
+      height: 40,
     },
     whiteColor: {
       color: styledColors.white,

--- a/src/main/settings/export/ExportPhraseScreen.tsx
+++ b/src/main/settings/export/ExportPhraseScreen.tsx
@@ -45,7 +45,7 @@ export const ExportPhraseScreen: React.FC<
     alert(t('export.phrase.phraseCopied'));
   };
   const goToConfirmPhrase = () =>
-    navigation.navigate('ExportConfirmationPhrase');
+    navigation.navigate('ExportConfirmationPhrase', { seedPhrase });
 
   return (
     <QuaiPayContent>

--- a/src/main/settings/export/ExportStack.tsx
+++ b/src/main/settings/export/ExportStack.tsx
@@ -14,7 +14,9 @@ import { ExportQRCodeScreen } from './ExportQRCode';
 export type ExportStackParamList = {
   ExportLanding: undefined;
   ExportPhrase: undefined;
-  ExportConfirmationPhrase: undefined;
+  ExportConfirmationPhrase: {
+    seedPhrase: string;
+  };
   ExportCheckout: undefined;
   ExportQRCode: undefined;
 };

--- a/src/main/settings/export/components/SeedPhraseConfirmation.tsx
+++ b/src/main/settings/export/components/SeedPhraseConfirmation.tsx
@@ -14,12 +14,19 @@ interface SeedPhraseConfirmationProps {
   setResult: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
-const WordBox = ({ onPress, word }: { onPress?: () => void; word: string }) => {
+interface WordBoxProps {
+  onPress?: (w: string) => void;
+  word: string;
+}
+
+const WordBox = ({ onPress, word }: WordBoxProps) => {
   const styles = useThemedStyle(themedStyle);
+
+  const handleOnPress = () => onPress && onPress(word);
 
   return (
     <Pressable
-      onPress={onPress}
+      onPress={handleOnPress}
       style={({ pressed }) => [styles.wordButton, pressed && { opacity: 0.5 }]}
     >
       <QuaiPayText style={styles.word}>{word}</QuaiPayText>
@@ -29,24 +36,40 @@ const WordBox = ({ onPress, word }: { onPress?: () => void; word: string }) => {
 
 export const SeedPhraseConfirmation: React.FC<SeedPhraseConfirmationProps> = ({
   seedPhrase,
+  result,
+  setResult,
 }) => {
   const styles = useThemedStyle(themedStyle);
 
   const seedPhraseWords = seedPhrase.split(' ');
+
+  const appendWord = (word: string) => {
+    if (result.find(w => w === word)) {
+      return;
+    }
+    setResult(prevState => [...prevState, word]);
+  };
+
+  const popWord = (word: string) => {
+    setResult(prevState => prevState.filter(w => word !== w));
+  };
+
   return (
     <>
       <View style={styles.mainContainer}>
         {seedPhraseWords.map((_, idx) => (
           <View key={idx} style={styles.emptyBox}>
-            <WordBox word={''} />
+            {result[idx] && <WordBox onPress={popWord} word={result[idx]} />}
           </View>
         ))}
       </View>
       <View style={styles.separator} />
       <View style={styles.mainContainer}>
         {seedPhraseWords.map((word, idx) => (
-          <View key={idx}>
-            <WordBox word={word} />
+          <View key={idx} style={styles.emptyBox}>
+            {!result.find(w => w === word) && (
+              <WordBox word={word} onPress={appendWord} />
+            )}
           </View>
         ))}
       </View>

--- a/src/main/settings/export/components/SeedPhraseConfirmation.tsx
+++ b/src/main/settings/export/components/SeedPhraseConfirmation.tsx
@@ -1,14 +1,17 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
+
 import { QuaiPayText } from 'src/shared/components';
 import { useThemedStyle } from 'src/shared/hooks/useThemedStyle';
 import { styledColors } from 'src/shared/styles';
 import { Theme } from 'src/shared/types';
+import { shuffle } from 'src/shared/utils/shuffle';
 
 const BOX_HEIGHT = 40;
 const BOX_WIDTH = 85;
 
 interface SeedPhraseConfirmationProps {
+  shouldShuffle?: boolean;
   seedPhrase: string;
   result: string[];
   setResult: React.Dispatch<React.SetStateAction<string[]>>;
@@ -35,13 +38,17 @@ const WordBox = ({ onPress, word }: WordBoxProps) => {
 };
 
 export const SeedPhraseConfirmation: React.FC<SeedPhraseConfirmationProps> = ({
+  shouldShuffle = true,
   seedPhrase,
   result,
   setResult,
 }) => {
   const styles = useThemedStyle(themedStyle);
 
-  const seedPhraseWords = seedPhrase.split(' ');
+  const seedPhraseWords = useMemo(
+    (arr = seedPhrase.split(' ')) => (shouldShuffle ? shuffle(arr) : arr),
+    [seedPhrase],
+  );
 
   const appendWord = (word: string) => {
     if (result.find(w => w === word)) {

--- a/src/main/settings/export/components/SeedPhraseConfirmation.tsx
+++ b/src/main/settings/export/components/SeedPhraseConfirmation.tsx
@@ -5,9 +5,25 @@ import { useThemedStyle } from 'src/shared/hooks/useThemedStyle';
 import { styledColors } from 'src/shared/styles';
 import { Theme } from 'src/shared/types';
 
+const BOX_HEIGHT = 40;
+const BOX_WIDTH = 85;
+
 interface SeedPhraseConfirmationProps {
   seedPhrase: string;
 }
+
+const WordBox = ({ onPress, word }: { onPress?: () => void; word: string }) => {
+  const styles = useThemedStyle(themedStyle);
+
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [styles.wordButton, pressed && { opacity: 0.5 }]}
+    >
+      <QuaiPayText style={styles.word}>{word}</QuaiPayText>
+    </Pressable>
+  );
+};
 
 export const SeedPhraseConfirmation: React.FC<SeedPhraseConfirmationProps> = ({
   seedPhrase,
@@ -17,23 +33,19 @@ export const SeedPhraseConfirmation: React.FC<SeedPhraseConfirmationProps> = ({
   const seedPhraseWords = seedPhrase.split(' ');
   return (
     <>
-      <View style={styles.wordFillerContainer}>
+      <View style={styles.mainContainer}>
         {seedPhraseWords.map((_, idx) => (
-          <View key={idx} style={styles.itemContainer}>
-            <View style={styles.word} />
+          <View key={idx} style={styles.emptyBox}>
+            <WordBox word={''} />
           </View>
         ))}
+      </View>
+      <View style={styles.separator} />
+      <View style={styles.mainContainer}>
         {seedPhraseWords.map((word, idx) => (
-          <Pressable
-            key={idx}
-            style={({ pressed }) => [
-              styles.itemContainer,
-              styles.wordButtonContainer,
-              pressed && { opacity: 0.5 },
-            ]}
-          >
-            <QuaiPayText style={styles.word}>{word}</QuaiPayText>
-          </Pressable>
+          <View key={idx}>
+            <WordBox word={word} />
+          </View>
         ))}
       </View>
     </>
@@ -42,37 +54,35 @@ export const SeedPhraseConfirmation: React.FC<SeedPhraseConfirmationProps> = ({
 
 const themedStyle = (theme: Theme) =>
   StyleSheet.create({
-    textContainer: {
-      flex: 1,
-      alignItems: 'center',
-      marginBottom: 20,
-    },
-    wordFillerContainer: {
+    mainContainer: {
       flexDirection: 'row',
       flexWrap: 'wrap',
-      justifyContent: 'flex-end',
+      justifyContent: 'space-between',
       gap: 8,
       marginHorizontal: 16,
-      paddingRight: 16,
+      paddingHorizontal: 16,
     },
-    itemContainer: {
-      width: '30%',
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'flex-end',
-      gap: 2,
-    },
-    wordButtonContainer: {
-      backgroundColor: theme.normal,
-    },
-    word: {
+    emptyBox: {
       borderWidth: 1,
       borderRadius: 4,
       borderColor: theme.border,
-      paddingTop: 10,
+      width: BOX_WIDTH,
+      height: BOX_HEIGHT,
+    },
+    wordButton: {
+      width: BOX_WIDTH,
+      flexDirection: 'row',
+      justifyContent: 'flex-end',
+      backgroundColor: theme.normal,
+      borderWidth: 1,
+      borderRadius: 4,
+      borderColor: theme.border,
+    },
+    word: {
+      paddingVertical: 12,
       paddingHorizontal: 8,
-      width: 85,
-      height: 40,
+      width: BOX_WIDTH,
+      height: BOX_HEIGHT,
       textAlign: 'left',
     },
     continueButton: {
@@ -82,7 +92,9 @@ const themedStyle = (theme: Theme) =>
       backgroundColor: theme.normal,
     },
     separator: {
-      height: 40,
+      borderWidth: 1,
+      borderColor: theme.border,
+      marginVertical: 18,
     },
     whiteColor: {
       color: styledColors.white,

--- a/src/main/settings/export/components/SeedPhraseConfirmation.tsx
+++ b/src/main/settings/export/components/SeedPhraseConfirmation.tsx
@@ -30,7 +30,11 @@ const WordBox = ({ onPress, word }: WordBoxProps) => {
   return (
     <Pressable
       onPress={handleOnPress}
-      style={({ pressed }) => [styles.wordButton, pressed && { opacity: 0.5 }]}
+      style={({ pressed }) => [
+        styles.box,
+        styles.wordButton,
+        pressed && { opacity: 0.5 },
+      ]}
     >
       <QuaiPayText style={styles.word}>{word}</QuaiPayText>
     </Pressable>
@@ -65,15 +69,24 @@ export const SeedPhraseConfirmation: React.FC<SeedPhraseConfirmationProps> = ({
     <>
       <View style={styles.mainContainer}>
         {seedPhraseWords.map((_, idx) => (
-          <View key={idx} style={styles.emptyBox}>
-            {result[idx] && <WordBox onPress={popWord} word={result[idx]} />}
+          <View
+            key={idx}
+            style={[styles.box, !result[idx] && styles.boxBorder]}
+          >
+            {!!result[idx] && <WordBox onPress={popWord} word={result[idx]} />}
           </View>
         ))}
       </View>
       <View style={styles.separator} />
       <View style={styles.mainContainer}>
         {seedPhraseWords.map((word, idx) => (
-          <View key={idx} style={styles.emptyBox}>
+          <View
+            key={idx}
+            style={[
+              styles.box,
+              !!result.find(w => w === word) && styles.boxBorder,
+            ]}
+          >
             {!result.find(w => w === word) && (
               <WordBox word={word} onPress={appendWord} />
             )}
@@ -94,28 +107,23 @@ const themedStyle = (theme: Theme) =>
       marginHorizontal: 16,
       paddingHorizontal: 16,
     },
-    emptyBox: {
-      borderWidth: 1,
-      borderRadius: 4,
-      borderColor: theme.border,
+    box: {
       width: BOX_WIDTH,
       height: BOX_HEIGHT,
+      borderRadius: 4,
+    },
+    boxBorder: {
+      borderWidth: 1,
+      borderColor: theme.border,
     },
     wordButton: {
-      width: BOX_WIDTH,
-      flexDirection: 'row',
-      justifyContent: 'flex-end',
       backgroundColor: theme.normal,
-      borderWidth: 1,
-      borderRadius: 4,
-      borderColor: theme.border,
     },
     word: {
       paddingVertical: 12,
       paddingHorizontal: 8,
-      width: BOX_WIDTH,
-      height: BOX_HEIGHT,
       textAlign: 'left',
+      color: styledColors.white,
     },
     continueButton: {
       marginBottom: 70,
@@ -124,7 +132,7 @@ const themedStyle = (theme: Theme) =>
       backgroundColor: theme.normal,
     },
     separator: {
-      borderWidth: 1,
+      borderTopWidth: 1,
       borderColor: theme.border,
       marginVertical: 18,
     },

--- a/src/main/settings/export/components/SeedPhraseConfirmation.tsx
+++ b/src/main/settings/export/components/SeedPhraseConfirmation.tsx
@@ -10,6 +10,8 @@ const BOX_WIDTH = 85;
 
 interface SeedPhraseConfirmationProps {
   seedPhrase: string;
+  result: string[];
+  setResult: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
 const WordBox = ({ onPress, word }: { onPress?: () => void; word: string }) => {

--- a/src/main/settings/export/components/SeedPhraseConfirmation.tsx
+++ b/src/main/settings/export/components/SeedPhraseConfirmation.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+import { QuaiPayText } from 'src/shared/components';
+import { useThemedStyle } from 'src/shared/hooks/useThemedStyle';
+import { styledColors } from 'src/shared/styles';
+import { Theme } from 'src/shared/types';
+
+interface SeedPhraseConfirmationProps {
+  seedPhrase: string;
+}
+
+export const SeedPhraseConfirmation: React.FC<SeedPhraseConfirmationProps> = ({
+  seedPhrase,
+}) => {
+  const styles = useThemedStyle(themedStyle);
+
+  const seedPhraseWords = seedPhrase.split(' ');
+  return (
+    <>
+      <View style={styles.wordFillerContainer}>
+        {seedPhraseWords.map((_, idx) => (
+          <View key={idx} style={styles.itemContainer}>
+            <View style={styles.word} />
+          </View>
+        ))}
+        {seedPhraseWords.map((word, idx) => (
+          <Pressable
+            key={idx}
+            style={({ pressed }) => [
+              styles.itemContainer,
+              styles.wordButtonContainer,
+              pressed && { opacity: 0.5 },
+            ]}
+          >
+            <QuaiPayText style={styles.word}>{word}</QuaiPayText>
+          </Pressable>
+        ))}
+      </View>
+    </>
+  );
+};
+
+const themedStyle = (theme: Theme) =>
+  StyleSheet.create({
+    textContainer: {
+      flex: 1,
+      alignItems: 'center',
+      marginBottom: 20,
+    },
+    wordFillerContainer: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      justifyContent: 'flex-end',
+      gap: 8,
+      marginHorizontal: 16,
+      paddingRight: 16,
+    },
+    itemContainer: {
+      width: '30%',
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'flex-end',
+      gap: 2,
+    },
+    wordButtonContainer: {
+      backgroundColor: theme.normal,
+    },
+    word: {
+      borderWidth: 1,
+      borderRadius: 4,
+      borderColor: theme.border,
+      paddingTop: 10,
+      paddingHorizontal: 8,
+      width: 85,
+      height: 40,
+      textAlign: 'left',
+    },
+    continueButton: {
+      marginBottom: 70,
+      padding: 10,
+      marginHorizontal: 30,
+      backgroundColor: theme.normal,
+    },
+    separator: {
+      height: 40,
+    },
+    whiteColor: {
+      color: styledColors.white,
+    },
+  });

--- a/src/shared/locales/de/export.json
+++ b/src/shared/locales/de/export.json
@@ -22,5 +22,9 @@
     "hidePhrase": "Seed-Phrase ausblenden",
     "copyToClipboard": "In Zwischenablage kopieren",
     "phraseCopied": "Seed-Phrase kopiert"
+  },
+  "confirmation": {
+    "title": "Seed-Phrase bestätigen",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus. Se"
   }
 }

--- a/src/shared/locales/de/export.json
+++ b/src/shared/locales/de/export.json
@@ -25,6 +25,7 @@
   },
   "confirmation": {
     "title": "Seed-Phrase bestätigen",
-    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus. Se"
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus. Se",
+    "wrongPhraseMessage": "Falsche Seed-Phrase. Überprüfen Sie Ihre Seed-Phrase und versuchen Sie es nochmal."
   }
 }

--- a/src/shared/locales/en/export.json
+++ b/src/shared/locales/en/export.json
@@ -25,6 +25,7 @@
   },
   "confirmation": {
     "title": "Confirm your seed phrase",
-    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus. Se"
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus. Se",
+    "wrongPhraseMessage": "Incorrect seed phrase. Please review your seed phrase and try again."
   }
 }

--- a/src/shared/locales/en/export.json
+++ b/src/shared/locales/en/export.json
@@ -22,5 +22,9 @@
     "hidePhrase": "Hide your Seed Phrase",
     "copyToClipboard": "Copy to Clipboard",
     "phraseCopied": "Seed Phrase copied"
+  },
+  "confirmation": {
+    "title": "Confirm your seed phrase",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus. Se"
   }
 }

--- a/src/shared/utils/shuffle.spec.ts
+++ b/src/shared/utils/shuffle.spec.ts
@@ -1,0 +1,20 @@
+import { shuffle } from './shuffle';
+
+describe('shuffle', () => {
+  it('should work strings[]', () => {
+    const input = 'This is a string array'.split(' ');
+    const output = shuffle(input);
+
+    expect(output).toHaveLength(input.length);
+    expect(output).not.toStrictEqual(input);
+    expect(output.sort()).toStrictEqual(input.sort());
+  });
+  it('should work numbers[]', () => {
+    const input = [1, 2, 3, 4, 5, 6];
+    const output = shuffle(input);
+
+    expect(output).toHaveLength(input.length);
+    expect(output).not.toStrictEqual(input);
+    expect(output.sort()).toStrictEqual(input.sort());
+  });
+});

--- a/src/shared/utils/shuffle.ts
+++ b/src/shared/utils/shuffle.ts
@@ -1,0 +1,22 @@
+export const shuffle = <T>(array: T[]) => {
+  // Create a copy
+  const result = [...array];
+
+  let currentIndex = result.length,
+    randomIndex;
+
+  // While there remain elements to shuffle.
+  while (currentIndex !== 0) {
+    // Pick a remaining element.
+    randomIndex = Math.floor(Math.random() * currentIndex);
+    currentIndex--;
+
+    // And swap it with the current element.
+    [result[currentIndex], result[randomIndex]] = [
+      result[randomIndex],
+      result[currentIndex],
+    ];
+  }
+
+  return result;
+};


### PR DESCRIPTION
## Description

With this PR, we are almost finishing the setup seed phrase part of the export flow. Now, the user will be able to validate if they correctly know their seed phrase by tapping on the words sequentially. 

If the array of words is incorrectly sorted, the user will be able to press the continue button (with a disabled style) and an alert will pop up with the error message (this will be replaced later with a Toast/SnackBar). However, if the user completed the seed phrase correctly, the CTA will be shown with the correct style and on press it will navigate to the next screen.

## Related Links

- Closes #110 

## Demo

| _iOS_ | _Android_ |
| :---: | :---: |
| <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/3003dac6-e609-4f7d-8915-65c58adea839' width=400> | <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/9ae47332-054d-420c-a741-2ec869ab5506' width=400> |