### PR TITLE
fix: phrase screen not retrieving & handling the entropy correctly

### DIFF
--- a/src/main/settings/export/ExportPhraseScreen.tsx
+++ b/src/main/settings/export/ExportPhraseScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Dimensions,
   Pressable,
@@ -17,7 +17,7 @@ import CopyOutline from 'src/shared/assets/copyOutline.svg';
 import { Theme } from 'src/shared/types';
 import { useThemedStyle } from 'src/shared/hooks/useThemedStyle';
 import { styledColors } from 'src/shared/styles';
-import { useWalletContext } from 'src/shared/context/walletContext';
+import { retrieveEntropy } from 'src/onboarding/services/retrieveEntropy';
 import { getSeedPhraseFromEntropy } from 'src/shared/utils/seedPhrase';
 
 import { SeedPhraseDisplay } from './components/SeedPhraseDisplay';
@@ -32,9 +32,15 @@ export const ExportPhraseScreen: React.FC<
   const { t } = useTranslation();
   const styles = useThemedStyle(themedStyle);
 
+  const [seedPhrase, setSeedPhrase] = useState<string>();
   const [isSeedPhraseHidden, setIsSeedPhraseHidden] = useState(true);
-  const { entropy } = useWalletContext();
-  const seedPhrase = entropy ? getSeedPhraseFromEntropy(entropy) : undefined;
+
+  useEffect(() => {
+    (async () =>
+      retrieveEntropy().then(value =>
+        setSeedPhrase(getSeedPhraseFromEntropy(value)),
+      ))();
+  }, []);
 
   const toggleShowSeedPhrase = () =>
     setIsSeedPhraseHidden(prevState => !prevState);

--- a/src/shared/context/walletContext.tsx
+++ b/src/shared/context/walletContext.tsx
@@ -1,24 +1,16 @@
-import React, { useEffect, useState } from 'react';
-
-import { retrieveEntropy } from 'src/onboarding/services/retrieveEntropy';
+import React, { useState } from 'react';
 
 import { createCtx } from '.';
 
 // State variables only
-interface WalletContextState {
-  entropy?: Uint8Array;
-}
+interface WalletContextState {}
 
 // This interface differentiates from State
 // because it holds any other option or fx
 // that handle the state in some way
-interface WalletContext extends WalletContextState {
-  setEntropy: (entropy: Uint8Array) => void;
-}
+interface WalletContext extends WalletContextState {}
 
-const INITIAL_STATE: WalletContextState = {
-  entropy: undefined,
-};
+const INITIAL_STATE: WalletContextState = {};
 
 const [useContext, WalletContextProvider] =
   createCtx<WalletContext>('walletContext');
@@ -26,26 +18,10 @@ const [useContext, WalletContextProvider] =
 export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const [state, setState] = useState<WalletContextState>(INITIAL_STATE);
-
-  // Fetch entropy from keychain at start up
-  useEffect(() => {
-    const initEntropy = async () => {
-      if (!state.entropy) {
-        retrieveEntropy().then(setEntropy).catch(console.error);
-      }
-      return;
-    };
-
-    initEntropy();
-  }, []);
-
-  // Exposing setter for onboarding flow to use after flow is finished
-  const setEntropy = (entropy: Uint8Array) =>
-    setState(prevState => ({ ...prevState, entropy }));
+  const [state, _] = useState<WalletContextState>(INITIAL_STATE);
 
   return (
-    <WalletContextProvider value={{ ...state, setEntropy }}>
+    <WalletContextProvider value={{ ...state }}>
       {children}
     </WalletContextProvider>
   );

--- a/src/shared/utils/seedPhrase.spec.ts
+++ b/src/shared/utils/seedPhrase.spec.ts
@@ -21,14 +21,18 @@ describe('entropyToSeedPhrase', () => {
   describe('with valid entropy', () => {
     it('should create a phrase of 12 words from 16 byte array', async () => {
       const input = await generateSecureRandom(16);
-      const output = getSeedPhraseFromEntropy(input);
+      const output = getSeedPhraseFromEntropy(
+        Buffer.from(input).toString('hex'),
+      );
 
       expect(output).toBeTruthy();
       expect(output?.split(' ')).toHaveLength(12);
     });
     it('should create a phrase of 24 words from 32 byte array', async () => {
       const input = await generateSecureRandom(32);
-      const output = getSeedPhraseFromEntropy(input);
+      const output = getSeedPhraseFromEntropy(
+        Buffer.from(input).toString('hex'),
+      );
 
       expect(output).toBeTruthy();
       expect(output?.split(' ')).toHaveLength(24);
@@ -43,7 +47,9 @@ describe('entropyToSeedPhrase', () => {
     });
     it('should return a falsy value for invalid length entropies', async () => {
       const input = await generateSecureRandom(4);
-      const output = getSeedPhraseFromEntropy(input);
+      const output = getSeedPhraseFromEntropy(
+        Buffer.from(input).toString('hex'),
+      );
 
       expect(output).toBeFalsy();
     });
@@ -52,7 +58,9 @@ describe('entropyToSeedPhrase', () => {
 
 describe('seedPhraseToEntropy', () => {
   it('should work with valid mnemonic phrase', () => {
-    const outputLength = getEntropyFromSeedPhrase(sampleMnemonic)?.byteLength;
+    const outputLength = Uint8Array.from(
+      Buffer.from(getEntropyFromSeedPhrase(sampleMnemonic) ?? '', 'hex'),
+    )?.byteLength;
 
     expect(outputLength).toBe((sampleMnemonic.split(' ').length * 8) / 6);
   });

--- a/src/shared/utils/seedPhrase.ts
+++ b/src/shared/utils/seedPhrase.ts
@@ -1,13 +1,12 @@
 import { entropyToMnemonic, mnemonicToEntropy } from 'bip39';
 
-export const getSeedPhraseFromEntropy = (entropy?: Uint8Array) => {
+export const getSeedPhraseFromEntropy = (entropy?: string) => {
   if (!entropy) {
     return undefined;
   }
 
   try {
-    const hexEntropy = Buffer.from(entropy).toString('hex');
-    const mnemonic = entropyToMnemonic(hexEntropy);
+    const mnemonic = entropyToMnemonic(entropy);
     return mnemonic;
   } catch {
     return undefined;
@@ -19,10 +18,7 @@ export const getEntropyFromSeedPhrase = (seedPhrase?: string) => {
     return undefined;
   }
   try {
-    const hexEntropy = mnemonicToEntropy(seedPhrase);
-    const entropy = Uint8Array.from(Buffer.from(hexEntropy, 'hex'));
-
-    return entropy;
+    return mnemonicToEntropy(seedPhrase);
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## Description

From our tests made while developing #144 (changes on #145), we found that the ExportPhraseScreen was somewhat broken.

Firstly, the encoding of the entropy was changed, so our local storage had the previous encoding and it was not working.

Secondly, again after the encoding change,  utils had to be rewritten (luckily not that much) to be useful for the new entropy type.

Lastly, the wallet context was cleaned up to avoid having unnecessary code there.

## Related links

- Closes #143 

## Demo

| _Wallet setup_ | _Export Phrase Screen_ |
| :---: | :---: |
| <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/25ebd9b0-5e54-4ba5-9cc9-8ddd9ff0ad2b' width=400> | <img src='https://github.com/dominant-strategies/quaipay/assets/21087992/4a580558-d0a9-4bf7-83f0-2880f495f7c0' width=400> |

| _Tests_ |
| :---: |
| <img width="400" alt="image" src="https://github.com/dominant-strategies/quaipay/assets/21087992/47c926d0-cf2a-455f-8407-4b7a53b61ba3"> |