### PR TITLE
feat: add wallet and entropy to context and change recov qr code

### DIFF
--- a/src/main/home/receive/ReceiveAmountInputScreen/index.tsx
+++ b/src/main/home/receive/ReceiveAmountInputScreen/index.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 
 import { fontStyle, styledColors } from 'src/shared/styles';
 import ExchangeIcon from 'src/shared/assets/exchange.svg';
-import { useProfilePicture, useUsername } from 'src/shared/hooks';
+import { useProfilePicture, useUsername, useWallet } from 'src/shared/hooks';
 import { useAmountInput } from 'src/shared/hooks/useAmountInput';
 import {
   QuaiPayContent,
@@ -19,19 +19,19 @@ import {
   QuaiPayKeyboard,
 } from 'src/shared/components';
 import { Currency } from 'src/shared/types';
+import { abbreviateAddress } from 'src/shared/services/quais';
 
 import { ReceiveStackScreenProps } from '../ReceiveStack';
-import { abbreviateAddress } from 'src/shared/services/quais';
 
 // TODO: improve L&F by using flex
 export const ReceiveAmountInputScreen: React.FC<
   ReceiveStackScreenProps<'ReceiveAmountInput'>
-> = ({ navigation, route }) => {
+> = ({ navigation }) => {
   const { t } = useTranslation();
   const isDarkMode = useColorScheme() === 'dark';
   const profilePicture = useProfilePicture();
   const username = useUsername();
-  const { wallet } = route.params;
+  const wallet = useWallet();
   const { eqInput, input, keyboard, onSwap } = useAmountInput();
 
   const textColor = {
@@ -45,7 +45,6 @@ export const ReceiveAmountInputScreen: React.FC<
   const goToGeneratedQR = () =>
     navigation.navigate('ReceiveQR', {
       amount: Number(input.unit === Currency.USD ? input.value : eqInput.value),
-      wallet,
     });
 
   return (

--- a/src/main/home/receive/ReceiveQRScreen/index.tsx
+++ b/src/main/home/receive/ReceiveQRScreen/index.tsx
@@ -11,24 +11,25 @@ import { useTranslation } from 'react-i18next';
 
 import { QuaiPayContent, QuaiPayQRCode } from 'src/shared/components';
 import { fontStyle, styledColors } from 'src/shared/styles';
-import { useUsername } from 'src/shared/hooks';
+import { useUsername, useWallet } from 'src/shared/hooks';
 import ExchangeIcon from 'src/shared/assets/exchange.svg';
 import { RootNavigator } from 'src/shared/navigation/utils';
 import { Currency } from 'src/shared/types';
 import { EXCHANGE_RATE } from 'src/shared/constants/exchangeRate';
+import { abbreviateAddress } from 'src/shared/services/quais';
 
 import { ReceiveStackScreenProps } from '../ReceiveStack';
 import ShareControl from '../ShareControl';
-import { abbreviateAddress } from 'src/shared/services/quais';
 
 export const ReceiveQRScreen: React.FC<
   ReceiveStackScreenProps<'ReceiveQR'>
 > = ({ route }) => {
-  const { amount, wallet } = route.params;
+  const { amount } = route.params;
 
   const isDarkMode = useColorScheme() === 'dark';
   const { t } = useTranslation();
   const username = useUsername();
+  const wallet = useWallet();
 
   const [mainAmount, setMainAmount] = useState(amount);
   const [eqAmount, setEqAmount] = useState(amount / EXCHANGE_RATE);

--- a/src/main/home/receive/ReceiveScreen/index.tsx
+++ b/src/main/home/receive/ReceiveScreen/index.tsx
@@ -32,6 +32,7 @@ export const ReceiveScreen = () => {
   const profilePicture = useProfilePicture();
   const username = useUsername();
   const wallet = useWallet();
+
   if (!profilePicture || !username || !wallet) {
     return <QuaiPayLoader text={'Loading...'} />;
   }
@@ -65,7 +66,6 @@ export const ReceiveScreen = () => {
           onPress={() => {
             navigation.navigate('ReceiveStack', {
               screen: 'ReceiveAmountInput',
-              params: { wallet },
             });
           }}
         >

--- a/src/main/home/receive/ReceiveStack.tsx
+++ b/src/main/home/receive/ReceiveStack.tsx
@@ -7,15 +7,11 @@ import {
 
 import { ReceiveAmountInputScreen } from './ReceiveAmountInputScreen';
 import { ReceiveQRScreen } from './ReceiveQRScreen';
-import { Wallet } from 'src/shared/types/Wallet';
 
 export type ReceiveStackParamList = {
-  ReceiveAmountInput: {
-    wallet: Wallet;
-  };
+  ReceiveAmountInput: undefined;
   ReceiveQR: {
     amount: number;
-    wallet: Wallet;
   };
 };
 

--- a/src/main/home/send/SendAmount/index.tsx
+++ b/src/main/home/send/SendAmount/index.tsx
@@ -20,7 +20,7 @@ import {
   QuaiPayText,
 } from 'src/shared/components';
 import ExchangeIcon from 'src/shared/assets/exchange.svg';
-import { useAmountInput } from 'src/shared/hooks';
+import { useAmountInput, useWallet } from 'src/shared/hooks';
 import { abbreviateAddress, getBalance } from 'src/shared/services/quais';
 import { Currency } from 'src/shared/types';
 import { fontStyle, styledColors } from 'src/shared/styles';
@@ -33,8 +33,9 @@ type SendAmountScreenProps = NativeStackScreenProps<
 >;
 
 const SendAmountScreen = ({ route, navigation }: SendAmountScreenProps) => {
-  const { amount, address, receiver, wallet, sender } = route.params;
+  const { amount, address, receiver, sender } = route.params;
   const { t } = useTranslation();
+  const wallet = useWallet();
   const isDarkMode = useColorScheme() === 'dark';
   const [quaiBalance, setQuaiBalance] = React.useState(0);
   const [hideBalance, setHideBalance] = React.useState(false);
@@ -72,7 +73,6 @@ const SendAmountScreen = ({ route, navigation }: SendAmountScreenProps) => {
       input,
       address,
       receiver,
-      wallet,
     });
   };
 
@@ -98,7 +98,6 @@ const SendAmountScreen = ({ route, navigation }: SendAmountScreenProps) => {
       input: input,
       address,
       receiver,
-      wallet,
       totalAmount: amountInUSD,
       tip: 0,
     });

--- a/src/main/home/send/SendConfirmation/index.tsx
+++ b/src/main/home/send/SendConfirmation/index.tsx
@@ -12,7 +12,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { QuaiPayBanner, QuaiPayText } from 'src/shared/components';
 import { buttonStyle, styledColors } from 'src/shared/styles';
-import { useAmountInput } from 'src/shared/hooks';
+import { useAmountInput, useWallet } from 'src/shared/hooks';
 import {
   abbreviateAddress,
   waitForTransaction,
@@ -32,7 +32,8 @@ type SendConfirmationScreenProps = NativeStackScreenProps<
 function SendConfirmationScreen({ route }: SendConfirmationScreenProps) {
   const { t } = useTranslation();
   const isDarkMode = useColorScheme() === 'dark';
-  const { wallet, sender, address, receiver, tip } = route.params;
+  const { sender, address, receiver, tip } = route.params;
+  const wallet = useWallet();
   const [showError, setShowError] = useState(false);
   const [txStatus, setTxStatus] = useState(TxStatus.pending);
   // TODO: remove when setShowError and setTxStatus are used
@@ -112,7 +113,7 @@ function SendConfirmationScreen({ route }: SendConfirmationScreenProps) {
             themeColor="secondary"
             style={styles.address}
           >
-            {abbreviateAddress(wallet.address)}
+            {abbreviateAddress(wallet?.address)}
           </QuaiPayText>
           <QuaiPayText style={styles.ends} type="bold">
             {t('common.sentTo')}

--- a/src/main/home/send/SendStack.tsx
+++ b/src/main/home/send/SendStack.tsx
@@ -7,14 +7,13 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useNavigation } from '@react-navigation/native';
 
 import { styledColors } from 'src/shared/styles';
-import { Currency } from 'src/shared/types';
+import { Currency, Transaction } from 'src/shared/types';
 
 import SendScanScreen from './SendScan';
 import SendAmountScreen from './SendAmount';
 import SendTipScreen from './SendTip';
 import SendOverviewScreen from './SendOverview';
 import SendConfirmationScreen from './SendConfirmation';
-import { Transaction, Wallet } from 'src/shared/types';
 
 export type SendStackParamList = {
   SendScan: { address: string; amount: number; username: string };
@@ -22,7 +21,6 @@ export type SendStackParamList = {
     address: string;
     amount: number;
     receiver: string;
-    wallet: Wallet;
     sender: string;
   };
   SendTip: {
@@ -39,10 +37,8 @@ export type SendStackParamList = {
     };
     amountInUSD: string;
     amountInQUAI: string;
-    wallet: Wallet;
   };
   SendOverview: {
-    wallet: Wallet;
     address: string;
     receiver: string;
     sender: string;
@@ -60,7 +56,6 @@ export type SendStackParamList = {
     totalAmount: string;
   };
   SendConfirmation: {
-    wallet: Wallet;
     transaction: Transaction;
     address: string;
     receiver: string;

--- a/src/main/settings/export/ExportPhraseScreen.tsx
+++ b/src/main/settings/export/ExportPhraseScreen.tsx
@@ -19,9 +19,8 @@ import EyeOutline from 'src/shared/assets/eyeOutline.svg';
 import HideIcon from 'src/shared/assets/hide.svg';
 import CopyOutline from 'src/shared/assets/copyOutline.svg';
 import { Theme } from 'src/shared/types';
-import { useThemedStyle } from 'src/shared/hooks/useThemedStyle';
+import { useEntropy, useThemedStyle } from 'src/shared/hooks';
 import { styledColors } from 'src/shared/styles';
-import { useWalletContext } from 'src/shared/context/walletContext';
 import { getSeedPhraseFromEntropy } from 'src/shared/utils/seedPhrase';
 
 import { SeedPhraseDisplay } from './components/SeedPhraseDisplay';
@@ -35,15 +34,13 @@ export const ExportPhraseScreen: React.FC<
 > = ({ navigation }) => {
   const { t } = useTranslation();
   const styles = useThemedStyle(themedStyle);
-  const { entropy, getEntropy } = useWalletContext();
+  const entropy = useEntropy();
 
   const [seedPhrase, setSeedPhrase] = useState<string>();
   const [isSeedPhraseHidden, setIsSeedPhraseHidden] = useState(true);
 
   useEffect(() => {
-    if (!entropy) {
-      getEntropy();
-    } else if (!seedPhrase) {
+    if (!seedPhrase && entropy) {
       setSeedPhrase(getSeedPhraseFromEntropy(entropy));
     }
   }, [entropy, seedPhrase]);

--- a/src/main/settings/export/ExportPhraseScreen.tsx
+++ b/src/main/settings/export/ExportPhraseScreen.tsx
@@ -21,7 +21,7 @@ import CopyOutline from 'src/shared/assets/copyOutline.svg';
 import { Theme } from 'src/shared/types';
 import { useThemedStyle } from 'src/shared/hooks/useThemedStyle';
 import { styledColors } from 'src/shared/styles';
-import { retrieveEntropy } from 'src/onboarding/services/retrieveEntropy';
+import { useWalletContext } from 'src/shared/context/walletContext';
 import { getSeedPhraseFromEntropy } from 'src/shared/utils/seedPhrase';
 
 import { SeedPhraseDisplay } from './components/SeedPhraseDisplay';
@@ -35,21 +35,24 @@ export const ExportPhraseScreen: React.FC<
 > = ({ navigation }) => {
   const { t } = useTranslation();
   const styles = useThemedStyle(themedStyle);
+  const { entropy, getEntropy } = useWalletContext();
 
   const [seedPhrase, setSeedPhrase] = useState<string>();
   const [isSeedPhraseHidden, setIsSeedPhraseHidden] = useState(true);
 
   useEffect(() => {
-    (async () =>
-      retrieveEntropy().then(value =>
-        setSeedPhrase(getSeedPhraseFromEntropy(value)),
-      ))();
-  }, []);
+    if (!entropy) {
+      getEntropy();
+    } else if (!seedPhrase) {
+      setSeedPhrase(getSeedPhraseFromEntropy(entropy));
+    }
+  }, [entropy, seedPhrase]);
 
   const toggleShowSeedPhrase = () =>
     setIsSeedPhraseHidden(prevState => !prevState);
   const copyToClipboard = () => {
     Clipboard.setString(seedPhrase ?? '');
+    // eslint-disable-next-line no-alert
     alert(t('export.phrase.phraseCopied'));
   };
   const goToConfirmPhrase = () =>

--- a/src/main/settings/export/ExportPhraseScreen.tsx
+++ b/src/main/settings/export/ExportPhraseScreen.tsx
@@ -19,6 +19,7 @@ import EyeOutline from 'src/shared/assets/eyeOutline.svg';
 import HideIcon from 'src/shared/assets/hide.svg';
 import CopyOutline from 'src/shared/assets/copyOutline.svg';
 import { Theme } from 'src/shared/types';
+import { useSnackBar } from 'src/shared/context/snackBarContext';
 import { useEntropy, useThemedStyle } from 'src/shared/hooks';
 import { styledColors } from 'src/shared/styles';
 import { getSeedPhraseFromEntropy } from 'src/shared/utils/seedPhrase';
@@ -35,6 +36,7 @@ export const ExportPhraseScreen: React.FC<
   const { t } = useTranslation();
   const styles = useThemedStyle(themedStyle);
   const entropy = useEntropy();
+  const { showSnackBar } = useSnackBar();
 
   const [seedPhrase, setSeedPhrase] = useState<string>();
   const [isSeedPhraseHidden, setIsSeedPhraseHidden] = useState(true);
@@ -49,8 +51,11 @@ export const ExportPhraseScreen: React.FC<
     setIsSeedPhraseHidden(prevState => !prevState);
   const copyToClipboard = () => {
     Clipboard.setString(seedPhrase ?? '');
-    // eslint-disable-next-line no-alert
-    alert(t('export.phrase.phraseCopied'));
+    showSnackBar({
+      message: 'Done',
+      moreInfo: t('export.phrase.phraseCopied') ?? '',
+      type: 'success',
+    });
   };
   const goToConfirmPhrase = () =>
     seedPhrase &&

--- a/src/main/settings/export/ExportQRCode.tsx
+++ b/src/main/settings/export/ExportQRCode.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { Pressable, StyleSheet, View } from 'react-native';
+import React, { useEffect } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -11,7 +11,6 @@ import { useWalletContext } from 'src/shared/context/walletContext';
 import { Theme } from 'src/shared/types';
 import { useThemedStyle } from 'src/shared/hooks/useThemedStyle';
 import { RootNavigator } from 'src/shared/navigation/utils';
-import { getSeedPhraseFromEntropy } from 'src/shared/utils/seedPhrase';
 
 import { ExportStackScreenProps } from './ExportStack';
 
@@ -21,15 +20,12 @@ export const ExportQRCodeScreen: React.FC<
   const { t } = useTranslation('translation', { keyPrefix: 'export.qrCode' });
   const styles = useThemedStyle(themedStyle);
   const { entropy, getEntropy } = useWalletContext();
-  const [mnemonicPhrase, setMnemonicPhrase] = useState<string>();
 
   useEffect(() => {
     if (!entropy) {
       getEntropy();
-    } else if (!mnemonicPhrase) {
-      setMnemonicPhrase(getSeedPhraseFromEntropy(entropy));
     }
-  }, [entropy, mnemonicPhrase]);
+  }, [entropy]);
 
   const goToSettings = () =>
     RootNavigator.navigate('Main', { screen: 'Settings' });
@@ -42,10 +38,14 @@ export const ExportQRCodeScreen: React.FC<
         <QuaiPayText type="paragraph" themeColor="secondary">
           {t('description')}
         </QuaiPayText>
-        <QuaiPayQRCode
-          containerStyle={styles.qrCodeContainer}
-          value={mnemonicPhrase}
-        />
+        {entropy ? (
+          <QuaiPayQRCode
+            containerStyle={styles.qrCodeContainer}
+            value={entropy}
+          />
+        ) : (
+          <ActivityIndicator color={styles.loader.color} />
+        )}
       </View>
       <QuaiPayText style={styles.underline} themeColor="secondary">
         {t('learnMore')}
@@ -94,5 +94,8 @@ const themedStyle = (theme: Theme) =>
     },
     underline: {
       textDecorationLine: 'underline',
+    },
+    loader: {
+      color: theme.secondary,
     },
   });

--- a/src/main/settings/export/ExportQRCode.tsx
+++ b/src/main/settings/export/ExportQRCode.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { ActivityIndicator, Pressable, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 
@@ -7,9 +7,8 @@ import {
   QuaiPayQRCode,
   QuaiPayText,
 } from 'src/shared/components';
-import { useWalletContext } from 'src/shared/context/walletContext';
 import { Theme } from 'src/shared/types';
-import { useThemedStyle } from 'src/shared/hooks/useThemedStyle';
+import { useEntropy, useThemedStyle } from 'src/shared/hooks';
 import { RootNavigator } from 'src/shared/navigation/utils';
 
 import { ExportStackScreenProps } from './ExportStack';
@@ -19,13 +18,7 @@ export const ExportQRCodeScreen: React.FC<
 > = ({}) => {
   const { t } = useTranslation('translation', { keyPrefix: 'export.qrCode' });
   const styles = useThemedStyle(themedStyle);
-  const { entropy, getEntropy } = useWalletContext();
-
-  useEffect(() => {
-    if (!entropy) {
-      getEntropy();
-    }
-  }, [entropy]);
+  const entropy = useEntropy();
 
   const goToSettings = () =>
     RootNavigator.navigate('Main', { screen: 'Settings' });

--- a/src/main/settings/export/ExportQRCode.tsx
+++ b/src/main/settings/export/ExportQRCode.tsx
@@ -7,27 +7,29 @@ import {
   QuaiPayQRCode,
   QuaiPayText,
 } from 'src/shared/components';
+import { useWalletContext } from 'src/shared/context/walletContext';
 import { Theme } from 'src/shared/types';
 import { useThemedStyle } from 'src/shared/hooks/useThemedStyle';
 import { RootNavigator } from 'src/shared/navigation/utils';
+import { getSeedPhraseFromEntropy } from 'src/shared/utils/seedPhrase';
 
 import { ExportStackScreenProps } from './ExportStack';
-import { getSeedPhraseFromEntropy } from 'src/shared/utils/seedPhrase';
-import { retrieveEntropy } from 'src/onboarding/services/retrieveEntropy';
 
 export const ExportQRCodeScreen: React.FC<
   ExportStackScreenProps<'ExportQRCode'>
 > = ({}) => {
   const { t } = useTranslation('translation', { keyPrefix: 'export.qrCode' });
   const styles = useThemedStyle(themedStyle);
+  const { entropy, getEntropy } = useWalletContext();
   const [mnemonicPhrase, setMnemonicPhrase] = useState<string>();
 
   useEffect(() => {
-    (async () =>
-      retrieveEntropy().then(value =>
-        setMnemonicPhrase(getSeedPhraseFromEntropy(value)),
-      ))();
-  }, []);
+    if (!entropy) {
+      getEntropy();
+    } else if (!mnemonicPhrase) {
+      setMnemonicPhrase(getSeedPhraseFromEntropy(entropy));
+    }
+  }, [entropy, mnemonicPhrase]);
 
   const goToSettings = () =>
     RootNavigator.navigate('Main', { screen: 'Settings' });

--- a/src/onboarding/screens/SetupWalletScreen.tsx
+++ b/src/onboarding/screens/SetupWalletScreen.tsx
@@ -24,7 +24,7 @@ type SetupWalletScreenProps = {
 
 function SetupWalletScreen({ navigation }: SetupWalletScreenProps) {
   const { isDarkMode } = useTheme();
-  const { setEntropy } = useWalletContext();
+  const { setEntropy, setWallet } = useWalletContext();
   const [settingUpWallet, setSettingUpWallet] = useState(false);
 
   const backgroundStyle = {
@@ -44,8 +44,9 @@ function SetupWalletScreen({ navigation }: SetupWalletScreenProps) {
   const onPressSetup = useCallback(async () => {
     try {
       setSettingUpWallet(true);
-      const { entropy } = await setUpWallet();
+      const { entropy, wallet } = await setUpWallet();
       setEntropy(entropy);
+      setWallet(wallet);
 
       navigation.navigate('SetupNameAndPFP');
     } catch (err) {

--- a/src/onboarding/screens/SetupWalletScreen.tsx
+++ b/src/onboarding/screens/SetupWalletScreen.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 import { Colors } from 'react-native/Libraries/NewAppScreen';
 
+import { useWalletContext } from 'src/shared/context/walletContext';
 import { fontStyle, buttonStyle, styledColors } from 'src/shared/styles';
 import { QuaiPayLoader } from 'src/shared/components';
 import { useTheme } from 'src/shared/context/themeContext';
@@ -23,6 +24,7 @@ type SetupWalletScreenProps = {
 
 function SetupWalletScreen({ navigation }: SetupWalletScreenProps) {
   const { isDarkMode } = useTheme();
+  const { setEntropy } = useWalletContext();
   const [settingUpWallet, setSettingUpWallet] = useState(false);
 
   const backgroundStyle = {
@@ -42,7 +44,8 @@ function SetupWalletScreen({ navigation }: SetupWalletScreenProps) {
   const onPressSetup = useCallback(async () => {
     try {
       setSettingUpWallet(true);
-      await setUpWallet();
+      const { entropy } = await setUpWallet();
+      setEntropy(entropy);
 
       navigation.navigate('SetupNameAndPFP');
     } catch (err) {

--- a/src/onboarding/services/retrieveEntropy.ts
+++ b/src/onboarding/services/retrieveEntropy.ts
@@ -1,12 +1,9 @@
 import { retrieveStoredItem } from 'src/shared/services/keychain';
 
 export async function retrieveEntropy() {
-  // TODO: remove type casting
-  const retrievedEntropy = (await retrieveStoredItem('entropy')) as
-    | string
-    | false;
-  if (retrievedEntropy === false) {
-    throw new Error('Entropy not found in keychain');
+  const retrievedEntropy = await retrieveStoredItem('entropy');
+  if (!retrievedEntropy) {
+    throw new Error('Entropy not found');
   }
   return retrievedEntropy;
 }

--- a/src/onboarding/services/setUpWallet.ts
+++ b/src/onboarding/services/setUpWallet.ts
@@ -45,6 +45,6 @@ export async function setUpWallet(entropy?: Uint8Array) {
   );
 
   return {
-    entropy,
+    entropy: encodedEntropy,
   };
 }

--- a/src/shared/components/QuaiPayCamera/QuaiPayCamera.hooks.ts
+++ b/src/shared/components/QuaiPayCamera/QuaiPayCamera.hooks.ts
@@ -40,7 +40,6 @@ const useSendAmountScannerCamera = () => {
             address,
             amount: amount || 0,
             receiver: username,
-            wallet,
             sender,
           },
         });

--- a/src/shared/components/QuaiPaySnackBar.tsx
+++ b/src/shared/components/QuaiPaySnackBar.tsx
@@ -16,24 +16,27 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { PanGestureHandler } from 'react-native-gesture-handler';
 
 import RedExclamation from 'src/shared/assets/redExclamation.svg';
+import Done from 'src/shared/assets/done.svg';
 
 import { QuaiPayText } from './QuaiPayText';
 import { useSnackBar } from '../context/snackBarContext';
 import { styledColors } from '../styles';
 
+const ICON_SIZE = 16;
 const SNACK_BAR_DURATION = 3000; // 3 seconds
 const SWIPE_THRESHOLD = 150;
 const Z_INDEX_SNACKBAR = 10;
 
 const SCREEN_WIDTH = Dimensions.get('screen').width;
 
-type QuaiPaySnackBarType = 'error';
+export type QuaiPaySnackBarType = 'error' | 'success';
 
 const snackBarIconByType: Record<
   QuaiPaySnackBarType,
   React.FC<React.SVGAttributes<SVGElement>>
 > = {
   error: RedExclamation,
+  success: Done,
 };
 
 interface QuaiPaySnackBarProps {
@@ -43,11 +46,10 @@ interface QuaiPaySnackBarProps {
 
 export const QuaiPaySnackBar: React.FC<QuaiPaySnackBarProps> = ({
   swipeAnimation = false,
-  type = 'error',
 }) => {
   const {
     isOpen,
-    snackBar: { message, moreInfo },
+    snackBar: { type, message, moreInfo },
     closeSnackBar,
   } = useSnackBar();
   const insets = useSafeAreaInsets();
@@ -100,9 +102,14 @@ export const QuaiPaySnackBar: React.FC<QuaiPaySnackBarProps> = ({
           entering={FadeInDown.delay(300)}
           exiting={FadeOutDown}
           layout={Layout.easing(Easing.linear)}
-          style={[styles.snackBar, styles.row, animatedStyle]}
+          style={[
+            styles.snackBar,
+            styles.row,
+            styles[`${type}Type`],
+            animatedStyle,
+          ]}
         >
-          <Icon />
+          <Icon height={ICON_SIZE} width={ICON_SIZE} />
           <QuaiPayText
             numberOfLines={1}
             adjustsFontSizeToFit
@@ -137,6 +144,14 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     marginHorizontal: 20,
     zIndex: 1000 + Z_INDEX_SNACKBAR,
+  },
+  errorType: {
+    backgroundColor: styledColors.alertBackground,
+  },
+  successType: {
+    backgroundColor: styledColors.light,
+    borderWidth: 1,
+    borderColor: styledColors.border,
   },
   row: {
     flexDirection: 'row',

--- a/src/shared/context/snackBarContext.tsx
+++ b/src/shared/context/snackBarContext.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from 'react';
 
 import { createCtx } from '.';
+import { QuaiPaySnackBarType } from '../components/QuaiPaySnackBar';
 
 export interface SnackBarInfo {
   message: string;
   moreInfo?: string;
+  type: QuaiPaySnackBarType;
 }
 
 // State variables only
@@ -25,7 +27,7 @@ const INITIAL_STATE: SnackBarContextState = {
   isOpen: false,
   snackBar: {
     message: '',
-    moreInfo: '',
+    type: 'error',
   },
 };
 

--- a/src/shared/context/walletContext.tsx
+++ b/src/shared/context/walletContext.tsx
@@ -1,14 +1,22 @@
 import React, { useState } from 'react';
 
+import { retrieveEntropy } from 'src/onboarding/services/retrieveEntropy';
+
 import { createCtx } from '.';
+import { useSnackBar } from './snackBarContext';
 
 // State variables only
-interface WalletContextState {}
+interface WalletContextState {
+  entropy?: string;
+}
 
 // This interface differentiates from State
 // because it holds any other option or fx
 // that handle the state in some way
-interface WalletContext extends WalletContextState {}
+interface WalletContext extends WalletContextState {
+  getEntropy: () => void;
+  setEntropy: (entropy: string) => void;
+}
 
 const INITIAL_STATE: WalletContextState = {};
 
@@ -18,10 +26,21 @@ const [useContext, WalletContextProvider] =
 export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const [state, _] = useState<WalletContextState>(INITIAL_STATE);
+  const [state, setState] = useState<WalletContextState>(INITIAL_STATE);
+  const { showSnackBar } = useSnackBar();
+
+  const getEntropy = () => {
+    retrieveEntropy()
+      .then(setEntropy)
+      .catch(e => showSnackBar({ message: 'Error', moreInfo: e }));
+  };
+
+  const setEntropy = (entropy: string) => {
+    setState(prevState => ({ ...prevState, entropy }));
+  };
 
   return (
-    <WalletContextProvider value={{ ...state }}>
+    <WalletContextProvider value={{ ...state, getEntropy, setEntropy }}>
       {children}
     </WalletContextProvider>
   );

--- a/src/shared/context/walletContext.tsx
+++ b/src/shared/context/walletContext.tsx
@@ -6,6 +6,7 @@ import { retrieveWallet } from '../services/retrieveWallet';
 import { createCtx } from '.';
 import { useSnackBar } from './snackBarContext';
 import { Wallet } from '../types';
+import { useTranslation } from 'react-i18next';
 
 // State variables only
 interface WalletContextState {
@@ -31,13 +32,19 @@ const [useContext, WalletContextProvider] =
 export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
+  const { t } = useTranslation();
   const [state, setState] = useState<WalletContextState>(INITIAL_STATE);
   const { showSnackBar } = useSnackBar();
 
   const getEntropy = () => {
     retrieveEntropy()
       .then(setEntropy)
-      .catch(e => showSnackBar({ message: 'Error', moreInfo: e }));
+      .catch(() =>
+        showSnackBar({
+          message: t('common.error'),
+          moreInfo: t('error.retrieve.entropy') ?? '',
+        }),
+      );
   };
 
   const setEntropy = (entropy: string) => {
@@ -49,8 +56,8 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({
       wallet
         ? setWallet(wallet)
         : showSnackBar({
-            message: 'Error',
-            moreInfo: 'Could not retrieve wallet',
+            message: t('common.error'),
+            moreInfo: t('error.retrieve.wallet') ?? '',
           }),
     );
   };

--- a/src/shared/context/walletContext.tsx
+++ b/src/shared/context/walletContext.tsx
@@ -1,13 +1,16 @@
 import React, { useState } from 'react';
 
 import { retrieveEntropy } from 'src/onboarding/services/retrieveEntropy';
+import { retrieveWallet } from '../services/retrieveWallet';
 
 import { createCtx } from '.';
 import { useSnackBar } from './snackBarContext';
+import { Wallet } from '../types';
 
 // State variables only
 interface WalletContextState {
   entropy?: string;
+  wallet?: Wallet;
 }
 
 // This interface differentiates from State
@@ -16,6 +19,8 @@ interface WalletContextState {
 interface WalletContext extends WalletContextState {
   getEntropy: () => void;
   setEntropy: (entropy: string) => void;
+  getWallet: () => void;
+  setWallet: (wallet?: Wallet) => void;
 }
 
 const INITIAL_STATE: WalletContextState = {};
@@ -39,8 +44,25 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({
     setState(prevState => ({ ...prevState, entropy }));
   };
 
+  const getWallet = () => {
+    retrieveWallet().then(wallet =>
+      wallet
+        ? setWallet(wallet)
+        : showSnackBar({
+            message: 'Error',
+            moreInfo: 'Could not retrieve wallet',
+          }),
+    );
+  };
+
+  const setWallet = (wallet?: Wallet) => {
+    setState(prevState => ({ ...prevState, wallet }));
+  };
+
   return (
-    <WalletContextProvider value={{ ...state, getEntropy, setEntropy }}>
+    <WalletContextProvider
+      value={{ ...state, getEntropy, setEntropy, getWallet, setWallet }}
+    >
       {children}
     </WalletContextProvider>
   );

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -1,5 +1,6 @@
 export { useAmountInput } from './useAmountInput';
 export { useContacts } from './useContacts';
+export { useEntropy } from './useEntropy';
 export { useProfilePicture } from './useProfilePicture';
 export { useRetrieve } from './useRetrieve';
 export { useThemedStyle } from './useThemedStyle';

--- a/src/shared/hooks/useEntropy.ts
+++ b/src/shared/hooks/useEntropy.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+
+import { useWalletContext } from '../context/walletContext';
+
+export const useEntropy = () => {
+  const { entropy, getEntropy } = useWalletContext();
+
+  useEffect(() => {
+    if (!entropy) {
+      getEntropy();
+    }
+  }, [entropy]);
+
+  return entropy;
+};

--- a/src/shared/hooks/useWallet.ts
+++ b/src/shared/hooks/useWallet.ts
@@ -1,18 +1,12 @@
-import { useEffect, useState } from 'react';
-import { retrieveWallet } from '../services/retrieveWallet';
-import { Wallet } from '../types';
+import { useEffect } from 'react';
+import { useWalletContext } from '../context/walletContext';
 
 export const useWallet = () => {
-  const [wallet, setWallet] = useState<Wallet>();
+  const { wallet, getWallet } = useWalletContext();
   useEffect(() => {
-    const retrieve = async () => {
-      const retrievedWallet = await retrieveWallet();
-      if (!retrievedWallet) {
-        throw new Error('Wallet not found');
-      }
-      setWallet(retrievedWallet);
-    };
-    retrieve();
-  }, []);
+    if (!wallet) {
+      getWallet();
+    }
+  }, [wallet]);
   return wallet;
 };

--- a/src/shared/locales/de/common.json
+++ b/src/shared/locales/de/common.json
@@ -6,4 +6,5 @@
   "to": "An",
   "sentTo": "Gesendet an",
   "learnMore": "Erfahren Sie mehr",
+  "error": "Fehler"
 }

--- a/src/shared/locales/de/errors.json
+++ b/src/shared/locales/de/errors.json
@@ -1,0 +1,6 @@
+{
+  "retrieve": {
+    "entropy": "Entropie nicht gefunden",
+    "wallet": "Wallet nicht gefunden"
+  }
+}

--- a/src/shared/locales/en/common.json
+++ b/src/shared/locales/en/common.json
@@ -5,5 +5,6 @@
   "from": "From",
   "to": "To",
   "sentTo": "Sent to",
-  "learnMore": "Learn more about QuaiPay"
+  "learnMore": "Learn more about QuaiPay",
+  "error": "Error"
 }

--- a/src/shared/locales/en/errors.json
+++ b/src/shared/locales/en/errors.json
@@ -1,0 +1,6 @@
+{
+  "retrieve": {
+    "entropy": "Entropy not found",
+    "wallet": "Wallet not found"
+  }
+}

--- a/src/shared/locales/index.ts
+++ b/src/shared/locales/index.ts
@@ -4,6 +4,8 @@ import { findBestLanguageTag } from 'react-native-localize';
 
 import common_en from './en/common.json';
 import common_de from './de/common.json';
+import error_en from './en/errors.json';
+import error_de from './de/errors.json';
 import home_en from './en/home.json';
 import home_de from './de/home.json';
 import onboarding_en from './en/onboarding.json';
@@ -22,6 +24,7 @@ i18n.use(initReactI18next).init({
     en: {
       translation: {
         common: common_en,
+        error: error_en,
         home: home_en,
         onboarding: onboarding_en,
         receive: receive_en,
@@ -32,6 +35,7 @@ i18n.use(initReactI18next).init({
     de: {
       translation: {
         common: common_de,
+        error: error_de,
         home: home_de,
         onboarding: onboarding_de,
         receive: receive_de,

--- a/src/shared/services/retrieveWallet.ts
+++ b/src/shared/services/retrieveWallet.ts
@@ -13,7 +13,7 @@ export const retrieveWallet = async (): Promise<Wallet | undefined> => {
   // location
   const retrievedWallet = await retrieveStoredItem(walletKey);
   if (!retrievedWallet) {
-    return undefined;
+    throw new Error('Wallet not found');
   }
   return JSON.parse(retrievedWallet);
 };


### PR DESCRIPTION
## Description

On this PR we add both the entropy and the wallet to WalletContext. After some discussion, we concluded that if we were to use the context, it couldn't be filled up on start up. Instead, whenever some of these values is needed, it would be retrieved (by means of passcode) and then stored. Thus, next time that value is needed, it will already be available without need of passcode.

With this change, we removed the wallets params that were passed on Receive and Send flows across screens and instead retrieve it with the hook.

Finally, we tweaked the Export's QR Code screen to use the entropy instead of the seed phrase.


## Related links

- Closes #149 
- Closes #150 

## Tests

To validate this new change we should check:
- Wallet keychain should be asked only one time
- Entropy keychain should be asked only one time

The testing steps are:
- Use send and receive flows. They should not break and behave as they were.
- Go to settings > export > Setup or Recover QR
  - Should ask for entropy the first time
  - Then it should not be asked again when browsing to either one of them