### PR TITLE
feat: add recovery flow's navigation

### DIFF
--- a/src/onboarding/OnboardingStack.tsx
+++ b/src/onboarding/OnboardingStack.tsx
@@ -5,7 +5,7 @@ import {
   StackScreenProps,
 } from '@react-navigation/stack';
 
-import { SetupWalletScreen } from './screens/SetupWalletScreen';
+import { OnboardingLandingScreen } from './screens/OnboardingLandingScreen';
 import { SetupNameAndPFPScreen } from './screens/SetupNameAndPFPScreen';
 import { SetupLocationScreen } from './screens/SetupLocationScreen';
 import { OnboardingTerms } from './screens/OnboardingTerms';
@@ -14,7 +14,7 @@ import { LoginQRCodeScanScreen } from './screens/LoginQRCodeScanScreen';
 import { LoginSeedPhraseInputScreen } from './screens/LoginSeedPhraseInputScreen';
 
 type OnboardingStackParamList = {
-  SetupWallet: undefined;
+  OnboardingLanding: undefined;
   SetupLocation: undefined;
   SetupNameAndPFP: undefined;
   OnboardingTerms: undefined;
@@ -37,9 +37,12 @@ const OnboardingStack = () => {
   return (
     <Stack.Navigator
       screenOptions={{ headerShown: false }}
-      initialRouteName="SetupWallet"
+      initialRouteName="OnboardingLanding"
     >
-      <Stack.Screen name="SetupWallet" component={SetupWalletScreen} />
+      <Stack.Screen
+        name="OnboardingLanding"
+        component={OnboardingLandingScreen}
+      />
       <Stack.Screen name="SetupLocation" component={SetupLocationScreen} />
       <Stack.Screen name="SetupNameAndPFP" component={SetupNameAndPFPScreen} />
       <Stack.Screen name="OnboardingTerms" component={OnboardingTerms} />

--- a/src/onboarding/OnboardingStack.tsx
+++ b/src/onboarding/OnboardingStack.tsx
@@ -10,6 +10,7 @@ import { SetupNameAndPFPScreen } from './screens/SetupNameAndPFPScreen';
 import { SetupLocationScreen } from './screens/SetupLocationScreen';
 import { LoginLandingScreen } from './screens/LoginLandingScreen';
 import { LoginQRCodeScanScreen } from './screens/LoginQRCodeScanScreen';
+import { LoginSeedPhraseInputScreen } from './screens/LoginSeedPhraseInputScreen';
 
 type OnboardingStackParamList = {
   SetupWallet: undefined;
@@ -17,6 +18,7 @@ type OnboardingStackParamList = {
   SetupNameAndPFP: undefined;
   LoginLanding: undefined;
   LoginQRCodeScan: undefined;
+  LoginSeedPhraseInput: undefined;
 };
 
 export type OnboardingStackNavigationProp<
@@ -40,6 +42,10 @@ const OnboardingStack = () => {
       <Stack.Screen name="SetupNameAndPFP" component={SetupNameAndPFPScreen} />
       <Stack.Screen name="LoginLanding" component={LoginLandingScreen} />
       <Stack.Screen name="LoginQRCodeScan" component={LoginQRCodeScanScreen} />
+      <Stack.Screen
+        name="LoginSeedPhraseInput"
+        component={LoginSeedPhraseInputScreen}
+      />
     </Stack.Navigator>
   );
 };

--- a/src/onboarding/OnboardingStack.tsx
+++ b/src/onboarding/OnboardingStack.tsx
@@ -9,12 +9,14 @@ import { SetupWalletScreen } from './screens/SetupWalletScreen';
 import { SetupNameAndPFPScreen } from './screens/SetupNameAndPFPScreen';
 import { SetupLocationScreen } from './screens/SetupLocationScreen';
 import { LoginLandingScreen } from './screens/LoginLandingScreen';
+import { LoginQRCodeScanScreen } from './screens/LoginQRCodeScanScreen';
 
 type OnboardingStackParamList = {
   SetupWallet: undefined;
   SetupLocation: undefined;
   SetupNameAndPFP: undefined;
   LoginLanding: undefined;
+  LoginQRCodeScan: undefined;
 };
 
 export type OnboardingStackNavigationProp<
@@ -37,6 +39,7 @@ const OnboardingStack = () => {
       <Stack.Screen name="SetupLocation" component={SetupLocationScreen} />
       <Stack.Screen name="SetupNameAndPFP" component={SetupNameAndPFPScreen} />
       <Stack.Screen name="LoginLanding" component={LoginLandingScreen} />
+      <Stack.Screen name="LoginQRCodeScan" component={LoginQRCodeScanScreen} />
     </Stack.Navigator>
   );
 };

--- a/src/onboarding/OnboardingStack.tsx
+++ b/src/onboarding/OnboardingStack.tsx
@@ -8,6 +8,7 @@ import {
 import { SetupWalletScreen } from './screens/SetupWalletScreen';
 import { SetupNameAndPFPScreen } from './screens/SetupNameAndPFPScreen';
 import { SetupLocationScreen } from './screens/SetupLocationScreen';
+import { OnboardingTerms } from './screens/OnboardingTerms';
 import { LoginLandingScreen } from './screens/LoginLandingScreen';
 import { LoginQRCodeScanScreen } from './screens/LoginQRCodeScanScreen';
 import { LoginSeedPhraseInputScreen } from './screens/LoginSeedPhraseInputScreen';
@@ -16,6 +17,7 @@ type OnboardingStackParamList = {
   SetupWallet: undefined;
   SetupLocation: undefined;
   SetupNameAndPFP: undefined;
+  OnboardingTerms: undefined;
   LoginLanding: undefined;
   LoginQRCodeScan: undefined;
   LoginSeedPhraseInput: undefined;
@@ -40,6 +42,7 @@ const OnboardingStack = () => {
       <Stack.Screen name="SetupWallet" component={SetupWalletScreen} />
       <Stack.Screen name="SetupLocation" component={SetupLocationScreen} />
       <Stack.Screen name="SetupNameAndPFP" component={SetupNameAndPFPScreen} />
+      <Stack.Screen name="OnboardingTerms" component={OnboardingTerms} />
       <Stack.Screen name="LoginLanding" component={LoginLandingScreen} />
       <Stack.Screen name="LoginQRCodeScan" component={LoginQRCodeScanScreen} />
       <Stack.Screen

--- a/src/onboarding/OnboardingStack.tsx
+++ b/src/onboarding/OnboardingStack.tsx
@@ -8,12 +8,13 @@ import {
 import { SetupWalletScreen } from './screens/SetupWalletScreen';
 import { SetupNameAndPFPScreen } from './screens/SetupNameAndPFPScreen';
 import { SetupLocationScreen } from './screens/SetupLocationScreen';
+import { LoginLandingScreen } from './screens/LoginLandingScreen';
 
 type OnboardingStackParamList = {
   SetupWallet: undefined;
   SetupLocation: undefined;
   SetupNameAndPFP: undefined;
-  Login: undefined;
+  LoginLanding: undefined;
 };
 
 export type OnboardingStackNavigationProp<
@@ -35,6 +36,7 @@ const OnboardingStack = () => {
       <Stack.Screen name="SetupWallet" component={SetupWalletScreen} />
       <Stack.Screen name="SetupLocation" component={SetupLocationScreen} />
       <Stack.Screen name="SetupNameAndPFP" component={SetupNameAndPFPScreen} />
+      <Stack.Screen name="LoginLanding" component={LoginLandingScreen} />
     </Stack.Navigator>
   );
 };

--- a/src/onboarding/OnboardingStack.tsx
+++ b/src/onboarding/OnboardingStack.tsx
@@ -1,34 +1,40 @@
 import React from 'react';
-import SetupWalletScreen from './screens/SetupWalletScreen';
-import SetupNameAndPFPScreen from './screens/SetupNameAndPFPScreen';
-import SetupLocationScreen from './screens/SetupLocationScreen';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import {
+  createStackNavigator,
+  StackNavigationProp,
+  StackScreenProps,
+} from '@react-navigation/stack';
 
-type HomeStackParamList = {
-  SetupWallet: any;
-  SetupLocation: any;
-  SetupNameAndPFP: any;
-  Login: any;
+import { SetupWalletScreen } from './screens/SetupWalletScreen';
+import { SetupNameAndPFPScreen } from './screens/SetupNameAndPFPScreen';
+import { SetupLocationScreen } from './screens/SetupLocationScreen';
+
+type OnboardingStackParamList = {
+  SetupWallet: undefined;
+  SetupLocation: undefined;
+  SetupNameAndPFP: undefined;
+  Login: undefined;
 };
-const Stack = createNativeStackNavigator<HomeStackParamList>();
+
+export type OnboardingStackNavigationProp<
+  Route extends keyof OnboardingStackParamList,
+> = StackNavigationProp<OnboardingStackParamList, Route>;
+
+export type OnboardingStackScreenProps<
+  Route extends keyof OnboardingStackParamList,
+> = StackScreenProps<OnboardingStackParamList, Route>;
+
+const Stack = createStackNavigator<OnboardingStackParamList>();
+
 const OnboardingStack = () => {
   return (
-    <Stack.Navigator initialRouteName="SetupWallet">
-      <Stack.Screen
-        component={SetupWalletScreen}
-        options={{ headerShown: false }}
-        name="SetupWallet"
-      />
-      <Stack.Screen
-        name="SetupLocation"
-        options={{ headerShown: false }}
-        component={SetupLocationScreen}
-      />
-      <Stack.Screen
-        options={{ headerShown: false }}
-        name="SetupNameAndPFP"
-        component={SetupNameAndPFPScreen}
-      />
+    <Stack.Navigator
+      screenOptions={{ headerShown: false }}
+      initialRouteName="SetupWallet"
+    >
+      <Stack.Screen name="SetupWallet" component={SetupWalletScreen} />
+      <Stack.Screen name="SetupLocation" component={SetupLocationScreen} />
+      <Stack.Screen name="SetupNameAndPFP" component={SetupNameAndPFPScreen} />
     </Stack.Navigator>
   );
 };

--- a/src/onboarding/screens/LoginLandingScreen.tsx
+++ b/src/onboarding/screens/LoginLandingScreen.tsx
@@ -9,6 +9,7 @@ export const LoginLandingScreen: React.FC<
   OnboardingStackScreenProps<'LoginLanding'>
 > = ({ navigation }) => {
   const goToQRCodeScan = () => navigation.navigate('LoginQRCodeScan');
+  const goToSeedPhraseInput = () => navigation.navigate('LoginSeedPhraseInput');
 
   return (
     <QuaiPayContent title="LoginLanding" containerStyle={styles.container}>
@@ -16,7 +17,10 @@ export const LoginLandingScreen: React.FC<
         title="Import wallet from device"
         onPress={goToQRCodeScan}
       />
-      <QuaiPayButton title="Enter your seed phrase" />
+      <QuaiPayButton
+        title="Enter your seed phrase"
+        onPress={goToSeedPhraseInput}
+      />
     </QuaiPayContent>
   );
 };

--- a/src/onboarding/screens/LoginLandingScreen.tsx
+++ b/src/onboarding/screens/LoginLandingScreen.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import { QuaiPayButton, QuaiPayContent } from 'src/shared/components';
+
+import { OnboardingStackScreenProps } from '../OnboardingStack';
+
+export const LoginLandingScreen: React.FC<
+  OnboardingStackScreenProps<'LoginLanding'>
+> = ({}) => {
+  return (
+    <QuaiPayContent title="LoginLanding" containerStyle={styles.container}>
+      <QuaiPayButton title="Import wallet from device" />
+      <QuaiPayButton title="Enter your seed phrase" />
+    </QuaiPayContent>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 40,
+    marginHorizontal: 20,
+  },
+});

--- a/src/onboarding/screens/LoginQRCodeScanScreen.tsx
+++ b/src/onboarding/screens/LoginQRCodeScanScreen.tsx
@@ -5,18 +5,16 @@ import { QuaiPayButton, QuaiPayContent } from 'src/shared/components';
 
 import { OnboardingStackScreenProps } from '../OnboardingStack';
 
-export const LoginLandingScreen: React.FC<
-  OnboardingStackScreenProps<'LoginLanding'>
+export const LoginQRCodeScanScreen: React.FC<
+  OnboardingStackScreenProps<'LoginQRCodeScan'>
 > = ({ navigation }) => {
-  const goToQRCodeScan = () => navigation.navigate('LoginQRCodeScan');
-
+  const onSuccessfulScan = () => {
+    // TODO: call to setup wallet with scanned entropy value
+    navigation.navigate('SetupNameAndPFP');
+  };
   return (
-    <QuaiPayContent title="LoginLanding" containerStyle={styles.container}>
-      <QuaiPayButton
-        title="Import wallet from device"
-        onPress={goToQRCodeScan}
-      />
-      <QuaiPayButton title="Enter your seed phrase" />
+    <QuaiPayContent title="LoginQRCodeScan" containerStyle={styles.container}>
+      <QuaiPayButton title="On Successful Scan" onPress={onSuccessfulScan} />
     </QuaiPayContent>
   );
 };

--- a/src/onboarding/screens/LoginSeedPhraseInputScreen.tsx
+++ b/src/onboarding/screens/LoginSeedPhraseInputScreen.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import { QuaiPayButton, QuaiPayContent } from 'src/shared/components';
+
+import { OnboardingStackScreenProps } from '../OnboardingStack';
+
+export const LoginSeedPhraseInputScreen: React.FC<
+  OnboardingStackScreenProps<'LoginSeedPhraseInput'>
+> = ({ navigation }) => {
+  const onSuccessful = () => {
+    // TODO: setup wallet with given seed phrase
+    navigation.navigate('SetupNameAndPFP');
+  };
+
+  return (
+    <QuaiPayContent
+      title="LoginSeedPhraseInput"
+      containerStyle={styles.container}
+    >
+      <QuaiPayButton title="On Successful Seed Phrase" onPress={onSuccessful} />
+    </QuaiPayContent>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 40,
+    marginHorizontal: 20,
+  },
+});

--- a/src/onboarding/screens/OnboardingLandingScreen.tsx
+++ b/src/onboarding/screens/OnboardingLandingScreen.tsx
@@ -19,8 +19,8 @@ import { useTheme } from 'src/shared/context/themeContext';
 import { setUpWallet } from '../services/setUpWallet';
 import { OnboardingStackScreenProps } from '../OnboardingStack';
 
-export const SetupWalletScreen: React.FC<
-  OnboardingStackScreenProps<'SetupWallet'>
+export const OnboardingLandingScreen: React.FC<
+  OnboardingStackScreenProps<'OnboardingLanding'>
 > = ({ navigation }) => {
   const { isDarkMode } = useTheme();
   const { setEntropy, setWallet } = useWalletContext();

--- a/src/onboarding/screens/OnboardingLandingScreen.tsx
+++ b/src/onboarding/screens/OnboardingLandingScreen.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-native/no-inline-styles */
-import React, { useCallback, useState } from 'react';
+import React from 'react';
 import {
   Image,
   SafeAreaView,
@@ -11,20 +11,16 @@ import {
 } from 'react-native';
 import { Colors } from 'react-native/Libraries/NewAppScreen';
 
-import { useWalletContext } from 'src/shared/context/walletContext';
 import { fontStyle, buttonStyle, styledColors } from 'src/shared/styles';
-import { QuaiPayButton, QuaiPayLoader } from 'src/shared/components';
+import { QuaiPayButton } from 'src/shared/components';
 import { useTheme } from 'src/shared/context/themeContext';
 
-import { setUpWallet } from '../services/setUpWallet';
 import { OnboardingStackScreenProps } from '../OnboardingStack';
 
 export const OnboardingLandingScreen: React.FC<
   OnboardingStackScreenProps<'OnboardingLanding'>
 > = ({ navigation }) => {
   const { isDarkMode } = useTheme();
-  const { setEntropy, setWallet } = useWalletContext();
-  const [settingUpWallet, setSettingUpWallet] = useState(false);
 
   const backgroundStyle = {
     backgroundColor: isDarkMode ? styledColors.black : styledColors.white,
@@ -40,30 +36,10 @@ export const OnboardingLandingScreen: React.FC<
     marginBottom: 'auto',
   };
 
-  const onPressSetup = useCallback(async () => {
-    try {
-      setSettingUpWallet(true);
-      const { entropy, wallet } = await setUpWallet();
-      setEntropy(entropy);
-      setWallet(wallet);
-
-      navigation.navigate('SetupNameAndPFP');
-    } catch (err) {
-      if (err instanceof Error) {
-        console.log('failed to set up wallet', err.message, err.stack);
-      } else {
-        console.log('failed to set up wallet', err);
-      }
-    } finally {
-      setSettingUpWallet(false);
-    }
-  }, [navigation]);
+  const goToOnboardingTerms = () => navigation.navigate('OnboardingTerms');
 
   const goToLogin = () => navigation.navigate('LoginLanding');
 
-  if (settingUpWallet) {
-    return <QuaiPayLoader text="Setting up wallet" />;
-  }
   return (
     <SafeAreaView style={backgroundStyle}>
       <StatusBar
@@ -101,7 +77,7 @@ export const OnboardingLandingScreen: React.FC<
         <View style={styles.loginActionSectionView}>
           <TouchableOpacity
             style={{ marginLeft: 21, marginRight: 21 }}
-            onPress={onPressSetup}
+            onPress={goToOnboardingTerms}
           >
             <Text
               style={{

--- a/src/onboarding/screens/OnboardingTerms.tsx
+++ b/src/onboarding/screens/OnboardingTerms.tsx
@@ -1,20 +1,47 @@
-import React, { useState } from 'react';
-
+import React, { useCallback, useState } from 'react';
 import { StyleSheet } from 'react-native';
+
+import {
+  QuaiPayButton,
+  QuaiPayContent,
+  QuaiPayLoader,
+} from 'src/shared/components';
+import { useWalletContext } from 'src/shared/context/walletContext';
+
 import { OnboardingStackScreenProps } from '../OnboardingStack';
-import { QuaiPayButton, QuaiPayContent } from 'src/shared/components';
+import { setUpWallet } from '../services/setUpWallet';
 
 export const OnboardingTerms: React.FC<
   OnboardingStackScreenProps<'OnboardingTerms'>
 > = ({ navigation }) => {
   const [termsAccepted, setTermsAccepted] = useState(false);
+  const { setEntropy, setWallet } = useWalletContext();
+  const [settingUpWallet, setSettingUpWallet] = useState(false);
 
   const toggleTerms = () => setTermsAccepted(prevState => !prevState);
 
-  const onContinue = () => {
-    // TODO: setup wallet
-    navigation.navigate('SetupLocation');
-  };
+  const onContinue = useCallback(async () => {
+    try {
+      setSettingUpWallet(true);
+      const { entropy, wallet } = await setUpWallet();
+      setEntropy(entropy);
+      setWallet(wallet);
+
+      navigation.navigate('SetupNameAndPFP');
+    } catch (err) {
+      if (err instanceof Error) {
+        console.log('failed to set up wallet', err.message, err.stack);
+      } else {
+        console.log('failed to set up wallet', err);
+      }
+    } finally {
+      setSettingUpWallet(false);
+    }
+  }, [navigation]);
+
+  if (settingUpWallet) {
+    return <QuaiPayLoader text="Setting up wallet" />;
+  }
 
   return (
     <QuaiPayContent title="OnBoardingTerms" containerStyle={styles.container}>

--- a/src/onboarding/screens/OnboardingTerms.tsx
+++ b/src/onboarding/screens/OnboardingTerms.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+
+import { StyleSheet } from 'react-native';
+import { OnboardingStackScreenProps } from '../OnboardingStack';
+import { QuaiPayButton, QuaiPayContent } from 'src/shared/components';
+
+export const OnboardingTerms: React.FC<
+  OnboardingStackScreenProps<'OnboardingTerms'>
+> = ({ navigation }) => {
+  const [termsAccepted, setTermsAccepted] = useState(false);
+
+  const toggleTerms = () => setTermsAccepted(prevState => !prevState);
+
+  const onContinue = () => {
+    // TODO: setup wallet
+    navigation.navigate('SetupLocation');
+  };
+
+  return (
+    <QuaiPayContent title="OnBoardingTerms" containerStyle={styles.container}>
+      <QuaiPayButton title="Press to accept terms" onPress={toggleTerms} />
+      <QuaiPayButton
+        disabled={!termsAccepted}
+        title="On Terms Accepted"
+        onPress={onContinue}
+      />
+    </QuaiPayContent>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 40,
+    marginHorizontal: 20,
+  },
+});

--- a/src/onboarding/screens/SetupLocationScreen.tsx
+++ b/src/onboarding/screens/SetupLocationScreen.tsx
@@ -1,10 +1,4 @@
 /* eslint-disable react-native/no-inline-styles */
-/**
- * Sample React Native App
- * https://github.com/facebook/react-native
- *
- * @format
- */
 
 import React, { useCallback, useState } from 'react';
 import Geolocation, {
@@ -30,12 +24,17 @@ import { keychainKeys } from 'src/shared/constants/keychainKeys';
 import { RootNavigator } from 'src/shared/navigation/utils';
 import { QuaiPayContent, QuaiPayLoader } from 'src/shared/components';
 
+import { OnboardingStackScreenProps } from '../OnboardingStack';
+
 async function getPosition(options?: GeoOptions): Promise<GeoPosition> {
   return new Promise((resolve, reject) =>
     Geolocation.getCurrentPosition(resolve, reject, options),
   );
 }
-function SetupLocationScreen() {
+
+export const SetupLocationScreen: React.FC<
+  OnboardingStackScreenProps<'SetupLocation'>
+> = () => {
   const isDarkMode = useColorScheme() === 'dark';
   const [gettingLocation, setGettingLocation] = useState(false);
 
@@ -159,7 +158,7 @@ function SetupLocationScreen() {
       </View>
     </QuaiPayContent>
   );
-}
+};
 
 const styles = StyleSheet.create({
   locationSetupTitle: {
@@ -191,5 +190,3 @@ const styles = StyleSheet.create({
     lineHeight: 20,
   },
 });
-
-export default SetupLocationScreen;

--- a/src/onboarding/screens/SetupNameAndPFPScreen.tsx
+++ b/src/onboarding/screens/SetupNameAndPFPScreen.tsx
@@ -1,10 +1,3 @@
-/**
- * Sample React Native App
- * https://github.com/facebook/react-native
- *
- * @format
- */
-
 import React, { useCallback, useState } from 'react';
 import {
   Image,
@@ -27,18 +20,18 @@ import { Theme } from 'src/shared/types';
 import { useThemedStyle } from 'src/shared/hooks/useThemedStyle';
 import { useTheme } from 'src/shared/context/themeContext';
 
+import { OnboardingStackScreenProps } from '../OnboardingStack';
+
 interface State {
   selectedImage: string;
 }
 
-type SetupNameAndPFPScreenProps = {
-  navigation: any;
-};
-
 const PFPURLPlaceholder =
   'https://www.pngfind.com/pngs/m/616-6168267_personblack-jack-kicking-at-camera-jack-black-transparent.png';
 
-function SetupNameAndPFPScreen({ navigation }: SetupNameAndPFPScreenProps) {
+export const SetupNameAndPFPScreen: React.FC<
+  OnboardingStackScreenProps<'SetupNameAndPFP'>
+> = ({ navigation }) => {
   const { t } = useTranslation();
   const [username, setUsername] = useState('');
   const [profilePicture, setProfilePicture] =
@@ -131,7 +124,7 @@ function SetupNameAndPFPScreen({ navigation }: SetupNameAndPFPScreenProps) {
       </QuaiPayContent>
     </DismissKeyboard>
   );
-}
+};
 const DismissKeyboard = ({ children }: any) => (
   <TouchableWithoutFeedback onPress={() => Keyboard.dismiss()}>
     {children}
@@ -200,5 +193,3 @@ const themedStyle = (theme: Theme) =>
       width: '100%',
     },
   });
-
-export default SetupNameAndPFPScreen;

--- a/src/onboarding/screens/SetupWalletScreen.tsx
+++ b/src/onboarding/screens/SetupWalletScreen.tsx
@@ -13,7 +13,7 @@ import { Colors } from 'react-native/Libraries/NewAppScreen';
 
 import { useWalletContext } from 'src/shared/context/walletContext';
 import { fontStyle, buttonStyle, styledColors } from 'src/shared/styles';
-import { QuaiPayLoader } from 'src/shared/components';
+import { QuaiPayButton, QuaiPayLoader } from 'src/shared/components';
 import { useTheme } from 'src/shared/context/themeContext';
 
 import { setUpWallet } from '../services/setUpWallet';
@@ -113,14 +113,13 @@ function SetupWalletScreen({ navigation }: SetupWalletScreenProps) {
               Setup{' '}
             </Text>
           </TouchableOpacity>
-          <Text
-            style={{ ...fontStyle.fontSmallText, ...styles.loginSection }}
-            onPress={() => {
-              // navigation.navigate('Login');
-            }}
-          >
-            Already have an account? Click here to login.
-          </Text>
+          <QuaiPayButton
+            title="Already have an account? Click here to login."
+            titleType="default"
+            type="secondary"
+            underline
+            style={styles.loginSection}
+          />
         </View>
         {/* </LinearGradient> */}
       </View>
@@ -156,10 +155,6 @@ const styles = StyleSheet.create({
   },
   loginActionSectionView: {},
   loginSection: {
-    color: Colors.black,
-    verticalAlign: 'middle',
-    textDecorationLine: 'underline',
-    textAlign: 'center',
     marginTop: 15,
   },
   welcomeDescriptionView: {

--- a/src/onboarding/screens/SetupWalletScreen.tsx
+++ b/src/onboarding/screens/SetupWalletScreen.tsx
@@ -59,6 +59,8 @@ export const SetupWalletScreen: React.FC<
     }
   }, [navigation]);
 
+  const goToLogin = () => navigation.navigate('LoginLanding');
+
   if (settingUpWallet) {
     return <QuaiPayLoader text="Setting up wallet" />;
   }
@@ -118,6 +120,7 @@ export const SetupWalletScreen: React.FC<
             type="secondary"
             underline
             style={styles.loginSection}
+            onPress={goToLogin}
           />
         </View>
         {/* </LinearGradient> */}

--- a/src/onboarding/screens/SetupWalletScreen.tsx
+++ b/src/onboarding/screens/SetupWalletScreen.tsx
@@ -17,12 +17,11 @@ import { QuaiPayButton, QuaiPayLoader } from 'src/shared/components';
 import { useTheme } from 'src/shared/context/themeContext';
 
 import { setUpWallet } from '../services/setUpWallet';
+import { OnboardingStackScreenProps } from '../OnboardingStack';
 
-type SetupWalletScreenProps = {
-  navigation: any;
-};
-
-function SetupWalletScreen({ navigation }: SetupWalletScreenProps) {
+export const SetupWalletScreen: React.FC<
+  OnboardingStackScreenProps<'SetupWallet'>
+> = ({ navigation }) => {
   const { isDarkMode } = useTheme();
   const { setEntropy, setWallet } = useWalletContext();
   const [settingUpWallet, setSettingUpWallet] = useState(false);
@@ -125,7 +124,7 @@ function SetupWalletScreen({ navigation }: SetupWalletScreenProps) {
       </View>
     </SafeAreaView>
   );
-}
+};
 
 const styles = StyleSheet.create({
   highlight: {
@@ -169,5 +168,3 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
   },
 });
-
-export default SetupWalletScreen;

--- a/src/shared/components/QuaiPayButton.tsx
+++ b/src/shared/components/QuaiPayButton.tsx
@@ -59,6 +59,10 @@ interface QuaiPayButtonProps extends Omit<PressableProps, 'style'> {
    * Typography to be used on title's component instead of the one on typed style
    */
   titleType?: Typography;
+  /*
+   * Underline title on button
+   */
+  underline?: boolean;
 }
 
 export const QuaiPayButton: React.FC<QuaiPayButtonProps> = ({
@@ -71,6 +75,7 @@ export const QuaiPayButton: React.FC<QuaiPayButtonProps> = ({
   pill = false,
   type = 'default',
   titleType = 'H3',
+  underline = false,
   ...props
 }) => {
   const buttonStyles = useThemedStyle(t =>
@@ -94,6 +99,7 @@ export const QuaiPayButton: React.FC<QuaiPayButtonProps> = ({
       >
         <QuaiPayText
           type={titleType}
+          underline={underline}
           style={[
             styles.text,
             outlined && styles.outlinedText,

--- a/src/shared/components/QuaiPayContent.tsx
+++ b/src/shared/components/QuaiPayContent.tsx
@@ -29,12 +29,14 @@ interface QuaiPayContentProps {
   noNavButton?: boolean;
   noInsetBottom?: boolean;
   title?: string | null;
+  style?: StyleProp<ViewStyle>;
 }
 
 export const QuaiPayContent: React.FC<QuaiPayContentProps> = ({
   children,
   containerStyle,
   handleGoBack,
+  style,
   hasBackgroundVariant = false,
   noNavButton = false,
   noInsetBottom = false,
@@ -74,7 +76,7 @@ export const QuaiPayContent: React.FC<QuaiPayContentProps> = ({
           paddingTop: insets.top,
           paddingBottom: noInsetBottom ? 0 : insets.bottom,
         },
-        ...(containerStyle ? [containerStyle] : []),
+        ...(style ? [style] : []),
       ]}
     >
       <StatusBar
@@ -104,7 +106,11 @@ export const QuaiPayContent: React.FC<QuaiPayContentProps> = ({
           )}
         </View>
       )}
-      {children}
+      <View
+        style={[styles.container, ...(containerStyle ? [containerStyle] : [])]}
+      >
+        {children}
+      </View>
     </View>
   );
 };

--- a/src/shared/components/QuaiPayText.tsx
+++ b/src/shared/components/QuaiPayText.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text, TextProps } from 'react-native';
+import { StyleSheet, Text, TextProps } from 'react-native';
 
 import { useTheme } from '../context/themeContext';
 import { ThemeColor, Typography } from '../types';
@@ -8,12 +8,14 @@ import { typography } from '../styles';
 interface IQuaiPayTextProps extends TextProps {
   themeColor?: keyof ThemeColor;
   type?: Typography;
+  underline?: boolean;
 }
 
 export const QuaiPayText: React.FC<IQuaiPayTextProps> = ({
   children,
   themeColor = 'primary',
   type = 'default',
+  underline = false,
   style,
   ...props
 }) => {
@@ -22,7 +24,12 @@ export const QuaiPayText: React.FC<IQuaiPayTextProps> = ({
 
   return (
     <Text
-      style={[fontStyle, { color: theme[themeColor] }, style]}
+      style={[
+        fontStyle,
+        { color: theme[themeColor] },
+        underline && styles.underline,
+        style,
+      ]}
       allowFontScaling={false}
       {...props}
     >
@@ -30,3 +37,9 @@ export const QuaiPayText: React.FC<IQuaiPayTextProps> = ({
     </Text>
   );
 };
+
+const styles = StyleSheet.create({
+  underline: {
+    textDecorationLine: 'underline',
+  },
+});


### PR DESCRIPTION
## Description

Before actually implementing the recovery functionality in the onboarding part of the app, we added the navigation and placeholder screens so that the connection between them is asserted.

Next, we shall implement screen by screen, adding functionality to them so that the user can login to their already initiated account.

## Related links
- Closes #51 

## Demo
 
| _Demo_ |
| :---: |
| <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/5bfbaa78-191d-4ff6-ba4f-f41c5ad65106' width=400> |