### PR TITLE
feat: add login/recovery via seed phrase

### DIFF
--- a/src/main/settings/export/components/SeedPhraseDisplay.tsx
+++ b/src/main/settings/export/components/SeedPhraseDisplay.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
 import { QuaiPayText } from 'src/shared/components';
+import {
+  QuaiPaySeedPhraseLayoutDisplay,
+  seedPhraseLayoutDisplayWordThemedStyle,
+} from 'src/shared/components/QuaiPaySeedPhraseLayoutDisplay';
 import { useThemedStyle } from 'src/shared/hooks/useThemedStyle';
-import { Theme } from 'src/shared/types';
 
 const placeholderWord = 'Octopus';
 const placeholderSecuredWord = placeholderWord.split('').map(() => '*');
@@ -13,51 +15,19 @@ interface SeedPhraseDisplayProps {
 }
 
 export const SeedPhraseDisplay: React.FC<SeedPhraseDisplayProps> = ({
-  hide = true,
+  hide = false,
   seedPhrase,
 }) => {
-  const styles = useThemedStyle(themedStyle);
+  const styles = useThemedStyle(seedPhraseLayoutDisplayWordThemedStyle);
 
   const seedPhraseWords = seedPhrase.split(' ');
   return (
-    <View style={styles.container}>
+    <QuaiPaySeedPhraseLayoutDisplay showIndex>
       {seedPhraseWords.map((word, idx) => (
-        <View key={idx} style={styles.itemContainer}>
-          <QuaiPayText>{idx + 1}.</QuaiPayText>
-          <QuaiPayText style={styles.word}>
-            {hide ? placeholderSecuredWord : word}
-          </QuaiPayText>
-        </View>
+        <QuaiPayText key={'sp-w-' + idx} style={styles.word}>
+          {hide ? placeholderSecuredWord : word}
+        </QuaiPayText>
       ))}
-    </View>
+    </QuaiPaySeedPhraseLayoutDisplay>
   );
 };
-
-const themedStyle = (theme: Theme) =>
-  StyleSheet.create({
-    container: {
-      flexDirection: 'row',
-      flexWrap: 'wrap',
-      justifyContent: 'flex-end',
-      gap: 8,
-      marginHorizontal: 16,
-      paddingRight: 16,
-    },
-    itemContainer: {
-      width: '30%',
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'flex-end',
-      gap: 2,
-    },
-    word: {
-      borderWidth: 1,
-      borderRadius: 4,
-      borderColor: theme.border,
-      paddingTop: 10,
-      paddingHorizontal: 8,
-      width: 85,
-      height: 40,
-      textAlign: 'left',
-    },
-  });

--- a/src/onboarding/screens/LoginSeedPhraseInputScreen.tsx
+++ b/src/onboarding/screens/LoginSeedPhraseInputScreen.tsx
@@ -28,8 +28,21 @@ export const LoginSeedPhraseInputScreen: React.FC<
 
   const changeWordOnPhrase = (value: string, idx: number) => {
     setSeedPhraseWords(prevState => {
-      prevState.splice(idx, 1, value); // Take element on idx and replace it with value
-      return prevState;
+      const parsedValue = value.split(' ');
+      if (parsedValue.length <= 1) {
+        // Take element on idx and replace it with value
+        prevState.splice(idx, 1, value);
+        return prevState;
+      } else if (parsedValue.length >= AMOUNT_OF_WORDS_IN_PHRASE) {
+        // Replace whole phrase and stop at the end (omit rest if any)
+        return parsedValue.splice(0, AMOUNT_OF_WORDS_IN_PHRASE);
+      } else {
+        // Paste from current until the end
+        return prevState.map((word, n) => {
+          const slicedId = (n - idx) % AMOUNT_OF_WORDS_IN_PHRASE;
+          return parsedValue[slicedId] ? parsedValue[slicedId] : word;
+        });
+      }
     });
   };
 

--- a/src/onboarding/screens/LoginSeedPhraseInputScreen.tsx
+++ b/src/onboarding/screens/LoginSeedPhraseInputScreen.tsx
@@ -1,10 +1,20 @@
 import React, { useState } from 'react';
-import { StyleSheet, TextInput } from 'react-native';
+import {
+  Dimensions,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  TextInput,
+  View,
+} from 'react-native';
 
+import BaselineError from 'src/shared/assets/baselineError.svg';
 import {
   QuaiPayButton,
   QuaiPayContent,
   QuaiPaySeedPhraseLayoutDisplay,
+  QuaiPayText,
   seedPhraseLayoutDisplayWordThemedStyle,
 } from 'src/shared/components';
 import { useThemedStyle } from 'src/shared/hooks';
@@ -13,12 +23,17 @@ import { typography } from 'src/shared/styles';
 import { getEntropyFromSeedPhrase } from 'src/shared/utils/seedPhrase';
 
 import { OnboardingStackScreenProps } from '../OnboardingStack';
+import { useTranslation } from 'react-i18next';
 
 const AMOUNT_OF_WORDS_IN_PHRASE = 24;
+
+const isWindowSmallerThanScreen =
+  Dimensions.get('window').height < Dimensions.get('screen').height;
 
 export const LoginSeedPhraseInputScreen: React.FC<
   OnboardingStackScreenProps<'LoginSeedPhraseInput'>
 > = ({ navigation }) => {
+  const { t } = useTranslation();
   const { word: wordStyle } = useThemedStyle(
     seedPhraseLayoutDisplayWordThemedStyle,
   );
@@ -65,26 +80,50 @@ export const LoginSeedPhraseInputScreen: React.FC<
   };
 
   return (
-    <QuaiPayContent
-      title="LoginSeedPhraseInput"
-      containerStyle={styles.container}
-    >
-      <QuaiPaySeedPhraseLayoutDisplay showIndex>
-        {seedPhraseWords.map((w, idx) => (
-          <TextInput
-            key={idx}
-            style={[typography.bold, wordStyle, styles.input, styles.textInput]}
-            defaultValue={w}
-            onChangeText={value => changeWordOnPhrase(value, idx)}
+    <QuaiPayContent containerStyle={styles.container}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      >
+        <ScrollView alwaysBounceVertical={isWindowSmallerThanScreen}>
+          <View style={styles.textContainer}>
+            <QuaiPayText type="H1" style={styles.title}>
+              {t('onboarding.login.phraseInput.title')}
+            </QuaiPayText>
+            <QuaiPayText type="paragraph" themeColor="secondary">
+              {t('onboarding.login.phraseInput.description')}
+            </QuaiPayText>
+          </View>
+          <View style={styles.bannerContainer}>
+            <BaselineError />
+            <QuaiPayText style={styles.bannerText}>
+              {t('onboarding.login.phraseInput.bannerMsg')}
+            </QuaiPayText>
+          </View>
+          <QuaiPaySeedPhraseLayoutDisplay showIndex>
+            {seedPhraseWords.map((w, idx) => (
+              <TextInput
+                key={idx}
+                style={[
+                  typography.bold,
+                  wordStyle,
+                  styles.input,
+                  styles.textInput,
+                ]}
+                defaultValue={w}
+                onChangeText={value => changeWordOnPhrase(value, idx)}
+              />
+            ))}
+          </QuaiPaySeedPhraseLayoutDisplay>
+          <View style={styles.separator} />
+          <QuaiPayButton
+            disabled={!isPhraseValid}
+            title={t('common.continue')}
+            onPress={onSuccessful}
+            style={styles.continue}
           />
-        ))}
-      </QuaiPaySeedPhraseLayoutDisplay>
-      <QuaiPayButton
-        disabled={!isPhraseValid}
-        title="On Successful Seed Phrase"
-        onPress={onSuccessful}
-        style={styles.continue}
-      />
+          <View style={styles.doubleSeparator} />
+        </ScrollView>
+      </KeyboardAvoidingView>
     </QuaiPayContent>
   );
 };
@@ -98,11 +137,41 @@ const themedStyle = (theme: Theme) =>
     },
     continue: {
       marginHorizontal: 20,
+      marginBottom: 12,
     },
     input: {
       paddingBottom: 10,
     },
     textInput: {
       color: theme.primary,
+    },
+    title: {
+      marginBottom: 8,
+    },
+    textContainer: {
+      alignItems: 'center',
+      marginHorizontal: 48,
+    },
+    bannerContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      backgroundColor: theme.surfaceVariant,
+      paddingVertical: 8,
+      paddingHorizontal: 16,
+      marginVertical: 16,
+      marginHorizontal: 58,
+      borderWidth: 1,
+      borderColor: theme.normal,
+      borderRadius: 4,
+      gap: 4,
+    },
+    bannerText: {
+      maxWidth: '90%',
+    },
+    separator: {
+      height: 40,
+    },
+    doubleSeparator: {
+      height: 80,
     },
   });

--- a/src/onboarding/screens/LoginSeedPhraseInputScreen.tsx
+++ b/src/onboarding/screens/LoginSeedPhraseInputScreen.tsx
@@ -1,13 +1,38 @@
-import React from 'react';
-import { StyleSheet } from 'react-native';
+import React, { useState } from 'react';
+import { StyleSheet, TextInput } from 'react-native';
 
-import { QuaiPayButton, QuaiPayContent } from 'src/shared/components';
+import {
+  QuaiPayButton,
+  QuaiPayContent,
+  QuaiPaySeedPhraseLayoutDisplay,
+  seedPhraseLayoutDisplayWordThemedStyle,
+} from 'src/shared/components';
+import { useThemedStyle } from 'src/shared/hooks';
+import { Theme } from 'src/shared/types';
+import { typography } from 'src/shared/styles';
 
 import { OnboardingStackScreenProps } from '../OnboardingStack';
+
+const AMOUNT_OF_WORDS_IN_PHRASE = 24;
 
 export const LoginSeedPhraseInputScreen: React.FC<
   OnboardingStackScreenProps<'LoginSeedPhraseInput'>
 > = ({ navigation }) => {
+  const { word: wordStyle } = useThemedStyle(
+    seedPhraseLayoutDisplayWordThemedStyle,
+  );
+  const styles = useThemedStyle(themedStyle);
+  const [seedPhraseWords, setSeedPhraseWords] = useState(
+    Array(AMOUNT_OF_WORDS_IN_PHRASE).fill(''),
+  );
+
+  const changeWordOnPhrase = (value: string, idx: number) => {
+    setSeedPhraseWords(prevState => {
+      prevState.splice(idx, 1, value); // Take element on idx and replace it with value
+      return prevState;
+    });
+  };
+
   const onSuccessful = () => {
     // TODO: setup wallet with given seed phrase
     navigation.navigate('SetupNameAndPFP');
@@ -18,16 +43,39 @@ export const LoginSeedPhraseInputScreen: React.FC<
       title="LoginSeedPhraseInput"
       containerStyle={styles.container}
     >
-      <QuaiPayButton title="On Successful Seed Phrase" onPress={onSuccessful} />
+      <QuaiPaySeedPhraseLayoutDisplay showIndex>
+        {seedPhraseWords.map((w, idx) => (
+          <TextInput
+            key={idx}
+            style={[typography.bold, wordStyle, styles.input, styles.textInput]}
+            defaultValue={w}
+            onChangeText={value => changeWordOnPhrase(value, idx)}
+          />
+        ))}
+      </QuaiPaySeedPhraseLayoutDisplay>
+      <QuaiPayButton
+        title="On Successful Seed Phrase"
+        onPress={onSuccessful}
+        style={styles.continue}
+      />
     </QuaiPayContent>
   );
 };
 
-const styles = StyleSheet.create({
-  container: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 40,
-    marginHorizontal: 20,
-  },
-});
+const themedStyle = (theme: Theme) =>
+  StyleSheet.create({
+    container: {
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 40,
+    },
+    continue: {
+      marginHorizontal: 20,
+    },
+    input: {
+      paddingBottom: 10,
+    },
+    textInput: {
+      color: theme.primary,
+    },
+  });

--- a/src/shared/components/QuaiPaySeedPhraseLayoutDisplay.tsx
+++ b/src/shared/components/QuaiPaySeedPhraseLayoutDisplay.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { Theme } from '../types';
+import { QuaiPayText } from './QuaiPayText';
+
+interface QuaiPaySeedPhraseLayoutDisplayProps {
+  children: React.ReactNode[];
+  showIndex?: boolean;
+}
+
+export const QuaiPaySeedPhraseLayoutDisplay: React.FC<
+  QuaiPaySeedPhraseLayoutDisplayProps
+> = ({ children, showIndex = false }) => {
+  return (
+    <View style={styles.container}>
+      {children.map((item, idx) => (
+        <View key={idx} style={styles.itemContainer}>
+          {showIndex && <QuaiPayText>{idx + 1}.</QuaiPayText>}
+          {item}
+        </View>
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'flex-end',
+    gap: 8,
+    marginHorizontal: 16,
+    paddingRight: 16,
+  },
+  itemContainer: {
+    width: '30%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    gap: 2,
+  },
+});
+
+export const seedPhraseLayoutDisplayWordThemedStyle = (theme: Theme) =>
+  StyleSheet.create({
+    word: {
+      borderWidth: 1,
+      borderRadius: 4,
+      borderColor: theme.border,
+      paddingTop: 10,
+      paddingHorizontal: 8,
+      width: 85,
+      height: 40,
+      textAlign: 'left',
+    },
+  });

--- a/src/shared/components/index.tsx
+++ b/src/shared/components/index.tsx
@@ -10,6 +10,10 @@ export { QuaiPayListItem } from './QuaiPayListItem';
 export { QuaiPayLoader } from './QuaiPayLoader';
 export { QuaiPayQRCode } from './QuaiPayQRCode';
 export { QuaiPaySearchbar } from './QuaiPaySearchbar';
+export {
+  QuaiPaySeedPhraseLayoutDisplay,
+  seedPhraseLayoutDisplayWordThemedStyle,
+} from './QuaiPaySeedPhraseLayoutDisplay';
 export { QuaiPaySnackBar } from './QuaiPaySnackBar';
 export { QuaiPayText } from './QuaiPayText';
 

--- a/src/shared/locales/de/onboarding.json
+++ b/src/shared/locales/de/onboarding.json
@@ -7,7 +7,14 @@
     "nameAndPFP": {
       "choose": "Benutzernamen und Profilbild auswählen",
       "username": "Benutzername",
-      "PFPURL": "Profilbild-URL",
+      "PFPURL": "Profilbild-URL"
+    }
+  },
+  "login": {
+    "phraseInput": {
+      "title": "Geben Sie Ihre Seed-Phrase ein",
+      "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus. Se",
+      "bannerMsg": "Sie können Ihre gesamte Seed-Phrase in eines der Felder einfügen."
     }
   }
 }

--- a/src/shared/locales/en/onboarding.json
+++ b/src/shared/locales/en/onboarding.json
@@ -7,7 +7,14 @@
     "nameAndPFP": {
       "choose": "Choose a username and profile picture",
       "username": "Username",
-      "PFPURL": "Profile picture URL",
+      "PFPURL": "Profile picture URL"
+    }
+  },
+  "login": {
+    "phraseInput": {
+      "title": "Enter your seed phrase",
+      "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus. Se",
+      "bannerMsg": "You can paste your entire seed phrase into any field."
     }
   }
 }


### PR DESCRIPTION
## Description

Following up on #154, we implemented the seed phrase input screen that will handle login via phrase in the onboarding. In a sentence it may be summed up as a screen with 24 inputs and a button that will show. itself enabled when the phrase is valid.

To fill up the phrase, the user may paste a 24 word-phrase they may have on their clipboard from independently from the input. If the clipboard phrase has more than 24 words, the others will be omitted. If it has less, they will be pasted from the posting onwards (trimming if no boxes are left unfilled).

Lastly, since the phrase is valid, we setup user's wallet there and when finished they browse to the name and pfp setup screen.

## Related links
- Closes #155 

## Demo

| _Demo_ |
| :---: |
| <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/031e0895-d595-4074-8033-85f5edf91bb4' width=400> |