### PR TITLE
feat: apply final UI tweaks to the onboarding terms screen

### DIFF
--- a/src/onboarding/screens/OnboardingTerms.tsx
+++ b/src/onboarding/screens/OnboardingTerms.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useState } from 'react';
-import { StyleSheet } from 'react-native';
+import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 
+import CheckBold from 'src/shared/assets/checkBold.svg';
 import {
   QuaiPayButton,
   QuaiPayContent,
@@ -9,6 +10,8 @@ import {
   QuaiPayText,
 } from 'src/shared/components';
 import { useWalletContext } from 'src/shared/context/walletContext';
+import { useThemedStyle } from 'src/shared/hooks';
+import { Theme } from 'src/shared/types';
 
 import { OnboardingStackScreenProps } from '../OnboardingStack';
 import { setUpWallet } from '../services/setUpWallet';
@@ -20,6 +23,8 @@ export const OnboardingTerms: React.FC<
     keyPrefix: 'onboarding.terms',
   });
   const { t: tCommon } = useTranslation('translation', { keyPrefix: 'common' });
+  const styles = useThemedStyle(themedStyle);
+
   const [termsAccepted, setTermsAccepted] = useState(false);
   const { setEntropy, setWallet } = useWalletContext();
   const [settingUpWallet, setSettingUpWallet] = useState(false);
@@ -51,24 +56,71 @@ export const OnboardingTerms: React.FC<
 
   return (
     <QuaiPayContent containerStyle={styles.container}>
-      <QuaiPayText>{t('title')}</QuaiPayText>
-      <QuaiPayText>{t('termsAndConditions')}</QuaiPayText>
-      <QuaiPayText>{t('termsContent')}</QuaiPayText>
-      <QuaiPayButton title={t('agree')} onPress={toggleTerms} />
+      <QuaiPayText type="H1">{t('title')}</QuaiPayText>
+      <View style={styles.separator} />
+      <ScrollView>
+        <QuaiPayText type="bold" style={styles.terms}>
+          {t('termsAndConditions')}
+        </QuaiPayText>
+        <QuaiPayText style={styles.terms}>{t('termsContent')}</QuaiPayText>
+      </ScrollView>
+      <Pressable onPress={toggleTerms} style={styles.agree}>
+        <View style={styles.checkBoldContainer}>
+          {termsAccepted ? (
+            <CheckBold />
+          ) : (
+            <View style={styles.checkBoldBlank} />
+          )}
+        </View>
+        <QuaiPayText style={styles.agreeText}>{t('agree')}</QuaiPayText>
+      </Pressable>
       <QuaiPayButton
         disabled={!termsAccepted}
         title={tCommon('continue')}
         onPress={onContinue}
       />
+      <View style={styles.doubleSeparator} />
     </QuaiPayContent>
   );
 };
 
-const styles = StyleSheet.create({
-  container: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 40,
-    marginHorizontal: 20,
-  },
-});
+const themedStyle = (theme: Theme) =>
+  StyleSheet.create({
+    container: {
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginHorizontal: 16,
+    },
+    terms: {
+      textAlign: 'left',
+      paddingHorizontal: 10,
+    },
+    agree: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      alignSelf: 'flex-start',
+      gap: 16,
+      marginBottom: 24,
+    },
+    agreeText: {
+      flexShrink: 1,
+      textAlign: 'left',
+      fontSize: 15,
+    },
+    checkBoldContainer: {
+      borderWidth: 1,
+      borderColor: theme.border,
+    },
+    checkBoldBlank: {
+      height: 24,
+      width: 24,
+    },
+    separator: {
+      marginVertical: 4,
+      flex: 1,
+    },
+    doubleSeparator: {
+      marginVertical: 4,
+      flex: 2,
+    },
+  });

--- a/src/onboarding/screens/OnboardingTerms.tsx
+++ b/src/onboarding/screens/OnboardingTerms.tsx
@@ -1,10 +1,12 @@
 import React, { useCallback, useState } from 'react';
 import { StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
 
 import {
   QuaiPayButton,
   QuaiPayContent,
   QuaiPayLoader,
+  QuaiPayText,
 } from 'src/shared/components';
 import { useWalletContext } from 'src/shared/context/walletContext';
 
@@ -14,6 +16,10 @@ import { setUpWallet } from '../services/setUpWallet';
 export const OnboardingTerms: React.FC<
   OnboardingStackScreenProps<'OnboardingTerms'>
 > = ({ navigation }) => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'onboarding.terms',
+  });
+  const { t: tCommon } = useTranslation('translation', { keyPrefix: 'common' });
   const [termsAccepted, setTermsAccepted] = useState(false);
   const { setEntropy, setWallet } = useWalletContext();
   const [settingUpWallet, setSettingUpWallet] = useState(false);
@@ -44,11 +50,14 @@ export const OnboardingTerms: React.FC<
   }
 
   return (
-    <QuaiPayContent title="OnBoardingTerms" containerStyle={styles.container}>
-      <QuaiPayButton title="Press to accept terms" onPress={toggleTerms} />
+    <QuaiPayContent containerStyle={styles.container}>
+      <QuaiPayText>{t('title')}</QuaiPayText>
+      <QuaiPayText>{t('termsAndConditions')}</QuaiPayText>
+      <QuaiPayText>{t('termsContent')}</QuaiPayText>
+      <QuaiPayButton title={t('agree')} onPress={toggleTerms} />
       <QuaiPayButton
         disabled={!termsAccepted}
-        title="On Terms Accepted"
+        title={tCommon('continue')}
         onPress={onContinue}
       />
     </QuaiPayContent>

--- a/src/shared/locales/de/onboarding.json
+++ b/src/shared/locales/de/onboarding.json
@@ -16,5 +16,11 @@
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus. Se",
       "bannerMsg": "Sie können Ihre gesamte Seed-Phrase in eines der Felder einfügen."
     }
+  },
+  "terms": {
+    "title": "QuaiPay ist eine selbstverwaltete Wallet, behandeln Sie sie wie Bargeld",
+    "termsAndConditions": "Allgemeine Geschäftsbedingungen",
+    "termsContent": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus. Sed dignissim, metus nec fringilla accumsan, risus sem sollicitudin lacus, ut interdum tellus elit sed risus. Maecenas eget condimentum\n\nLorem ipsum dolor sit\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus. Sed dignissim, metus nec fringilla accumsan, risus sem sollicitudin lacus, ut interdum tellus elit sed risus. Maecenas eget condimentum\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus. Sed dignissim, metus nec fringilla accumsan, risus sem sollicitudin lacus, ut interdum tellus elit sed risus. Maecenas eget condimentum\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus. Sed\nLorem ipsum dolor sit amet, consectetur adipiscing elit. ",
+    "agree": "Ich stimme den Allgemeinen Geschäftsbedingungen zu."
   }
 }

--- a/src/shared/locales/en/onboarding.json
+++ b/src/shared/locales/en/onboarding.json
@@ -16,5 +16,11 @@
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus. Se",
       "bannerMsg": "You can paste your entire seed phrase into any field."
     }
+  },
+  "terms": {
+    "title": "QuaiPay is a self custody wallet, treat it like cash",
+    "termsAndConditions": "Terms and Conditions",
+    "termsContent": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus. Sed dignissim, metus nec fringilla accumsan, risus sem sollicitudin lacus, ut interdum tellus elit sed risus. Maecenas eget condimentum\n\nLorem ipsum dolor sit\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus. Sed dignissim, metus nec fringilla accumsan, risus sem sollicitudin lacus, ut interdum tellus elit sed risus. Maecenas eget condimentum\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus. Sed dignissim, metus nec fringilla accumsan, risus sem sollicitudin lacus, ut interdum tellus elit sed risus. Maecenas eget condimentum\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus. Sed\nLorem ipsum dolor sit amet, consectetur adipiscing elit. ",
+    "agree": "I agree to the Terms and Conditions."
   }
 }


### PR DESCRIPTION
## Description

In this PR, we add basic UI to the T&C screen on the onboarding flow.

Next up, we need to add the proper T&C content and apply the corresponding styling.

## Related links
- Closes #172 

## Demo

| _Dark_ | _Light_ |
| :--: | :--: |
| <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/4cade781-08ca-4708-a281-7719ba48f76e' width=400> | <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/86792fb8-9230-41e3-8e41-78011be3afa1' width=400> |