### PR TITLE
feat(android): forbid screen capture globally

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -6,8 +6,10 @@
 
     <application
         android:usesCleartextTraffic="true"
+        android:supportsRtl="true"
         tools:targetApi="28"
-        tools:ignore="GoogleAppIndexingWarning">
+        tools:ignore="GoogleAppIndexingWarning"
+        >
         <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="false" />
-    </application android:supportsRtl="true">
+    </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+      android:supportsRtl="true">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
@@ -23,5 +24,5 @@
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
       </activity>
-    </application android:supportsRtl="true">
+    </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,9 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
     <application
       android:name=".MainApplication"
       android:label="@string/app_name"

--- a/android/app/src/main/java/com/quai/MainActivity.java
+++ b/android/app/src/main/java/com/quai/MainActivity.java
@@ -5,6 +5,9 @@ import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
 import com.facebook.react.defaults.DefaultReactActivityDelegate;
 
+import android.view.WindowManager;
+import android.os.Bundle;
+
 public class MainActivity extends ReactActivity {
 
   /**
@@ -31,5 +34,18 @@ public class MainActivity extends ReactActivity {
         // If you opted-in for the New Architecture, we enable Concurrent React (i.e. React 18).
         DefaultNewArchitectureEntryPoint.getConcurrentReactEnabled() // concurrentRootEnabled
         );
+  }
+
+  /**
+   * Override onCreate to avoid screenshots for the whole app
+   */
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    getWindow().setFlags(
+        WindowManager.LayoutParams.FLAG_SECURE,
+        WindowManager.LayoutParams.FLAG_SECURE
+    );
   }
 }


### PR DESCRIPTION
## Description

As part of the design spec, the user should not be able to take screenshots of their recovery seed phrase when shown on screen.

This PR is the first brute force approach to that, where we block screenshot capabilities for the whole app on Android. The practice is quiet common but not ideal. Thus, we first set that up as a worse-case scenario and then we will iterate to specify which screens to flag as secure (and with that forbidding screenshots there).

Next, we shall also forbid screenshots for iOS which requires a more elaborate solution than this one (#217)

## Related links

- Closes #121 
- Related to #217 

## Demos

| _Before_ |
| :---: |
| <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/64c54e97-9ed0-4b79-a20f-aac7d7b1fdd8'> |

| _After_ |
| :---: |
| <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/f0e909d3-d12a-4e07-9de4-21a29ecb157b'> |