### PR TITLE
feat: shorten mnemonic verification on export

### DIFF
--- a/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
+++ b/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
@@ -44,7 +44,8 @@ export const ExportConfirmationPhraseScreen: React.FC<
 
   const isPhraseComplete =
     proposedSeedPhraseWords.length === expectedWords.length;
-  const isPhraseOk = expectedWords === proposedSeedPhraseWords;
+  const isPhraseOk =
+    expectedWords.join(' ') === proposedSeedPhraseWords.join(' ');
 
   const handleCTAPress = () =>
     isPhraseOk ? goToCheckout() : popWrongPhraseMessage();

--- a/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
+++ b/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
@@ -9,7 +9,10 @@ import { useSnackBar } from 'src/shared/context/snackBarContext';
 import { styledColors } from 'src/shared/styles';
 
 import { ExportStackScreenProps } from './ExportStack';
-import { SeedPhraseConfirmation } from './components/SeedPhraseConfirmation';
+import {
+  SeedPhraseConfirmation,
+  getIndexesToConfirm,
+} from './components/SeedPhraseConfirmation';
 
 export const ExportConfirmationPhraseScreen: React.FC<
   ExportStackScreenProps<'ExportConfirmationPhrase'>
@@ -31,6 +34,8 @@ export const ExportConfirmationPhraseScreen: React.FC<
     proposedSeedPhrase.length === seedPhrase.split('').length;
   const isPhraseOk = seedPhrase === proposedSeedPhrase;
 
+  const indexesToConfirm = getIndexesToConfirm(seedPhrase);
+
   const handleCTAPress = () =>
     isPhraseOk ? goToCheckout() : popWrongPhraseMessage();
   const popWrongPhraseMessage = () =>
@@ -48,12 +53,17 @@ export const ExportConfirmationPhraseScreen: React.FC<
           <QuaiPayText type="H1">{t('export.confirmation.title')}</QuaiPayText>
           <QuaiPayText type="H3">
             {t('export.confirmation.description')}
+            {/* TODO: review proper copy for this section */}
+            {`\n\nInput the words with position ${indexesToConfirm.join(
+              ', ',
+            )} in the right order.`}
           </QuaiPayText>
         </View>
         <SeedPhraseConfirmation
           seedPhrase={seedPhrase}
           result={proposedSeedPhraseWords}
           setResult={setProposedSeedPhraseWords}
+          indexesToConfirm={indexesToConfirm}
         />
         <View style={styles.separator} />
         <Pressable

--- a/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
+++ b/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 
@@ -34,7 +34,10 @@ export const ExportConfirmationPhraseScreen: React.FC<
     proposedSeedPhrase.length === seedPhrase.split('').length;
   const isPhraseOk = seedPhrase === proposedSeedPhrase;
 
-  const indexesToConfirm = getIndexesToConfirm(seedPhrase);
+  const indexesToConfirm = useMemo(
+    () => getIndexesToConfirm(seedPhrase),
+    [seedPhrase],
+  );
 
   const handleCTAPress = () =>
     isPhraseOk ? goToCheckout() : popWrongPhraseMessage();

--- a/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
+++ b/src/main/settings/export/ExportConfirmationPhraseScreen.tsx
@@ -29,15 +29,22 @@ export const ExportConfirmationPhraseScreen: React.FC<
     string[]
   >([]);
 
-  const proposedSeedPhrase = proposedSeedPhraseWords.join(' ');
-  const isPhraseComplete =
-    proposedSeedPhrase.length === seedPhrase.split('').length;
-  const isPhraseOk = seedPhrase === proposedSeedPhrase;
-
   const indexesToConfirm = useMemo(
     () => getIndexesToConfirm(seedPhrase),
     [seedPhrase],
   );
+
+  const expectedWords = useMemo(
+    () =>
+      seedPhrase
+        .split(' ')
+        .filter((_, idx) => indexesToConfirm.find(index => index === idx)),
+    [seedPhrase],
+  );
+
+  const isPhraseComplete =
+    proposedSeedPhraseWords.length === expectedWords.length;
+  const isPhraseOk = expectedWords === proposedSeedPhraseWords;
 
   const handleCTAPress = () =>
     isPhraseOk ? goToCheckout() : popWrongPhraseMessage();
@@ -57,9 +64,9 @@ export const ExportConfirmationPhraseScreen: React.FC<
           <QuaiPayText type="H3">
             {t('export.confirmation.description')}
             {/* TODO: review proper copy for this section */}
-            {`\n\nInput the words with position ${indexesToConfirm.join(
-              ', ',
-            )} in the right order.`}
+            {`\n\nInput the words with position ${indexesToConfirm
+              .map(value => value + 1)
+              .join(', ')} in the right order.`}
           </QuaiPayText>
         </View>
         <SeedPhraseConfirmation

--- a/src/main/settings/export/components/SeedPhraseConfirmation.tsx
+++ b/src/main/settings/export/components/SeedPhraseConfirmation.tsx
@@ -48,7 +48,7 @@ const WordBox = ({ disabled = false, onPress, word }: WordBoxProps) => {
 
 // Shuffles indexes and returns a sorted array of indexes to confirm
 export const getIndexesToConfirm = (seedPhrase: string) =>
-  shuffle([...seedPhrase.split(' ')].map((_, idx) => idx))
+  shuffle(seedPhrase.split(' ').map((_, idx) => idx))
     .slice(0, AMOUNT_OF_WORDS_TO_CONFIRM)
     .sort((a, b) => a - b);
 
@@ -66,15 +66,7 @@ export const SeedPhraseConfirmation: React.FC<SeedPhraseConfirmationProps> = ({
     [seedPhrase],
   );
 
-  const expectedWords = useMemo(
-    () =>
-      seedPhraseWords.filter((_, idx) =>
-        indexesToConfirm.find(index => index === idx),
-      ),
-    [seedPhraseWords],
-  );
-
-  const hasFullAnswer = result.length === expectedWords.length;
+  const hasFullAnswer = result.length === indexesToConfirm.length;
 
   const appendWord = (word: string) => {
     if (hasFullAnswer) {
@@ -93,7 +85,7 @@ export const SeedPhraseConfirmation: React.FC<SeedPhraseConfirmationProps> = ({
   return (
     <>
       <View style={styles.mainContainer}>
-        {expectedWords.map((_, idx) => (
+        {indexesToConfirm.map((_, idx) => (
           <View
             key={idx}
             style={[styles.box, !result[idx] && styles.boxBorder]}

--- a/src/main/settings/export/components/SeedPhraseConfirmation.tsx
+++ b/src/main/settings/export/components/SeedPhraseConfirmation.tsx
@@ -10,6 +10,8 @@ import { shuffle } from 'src/shared/utils/shuffle';
 const BOX_HEIGHT = 40;
 const BOX_WIDTH = 85;
 
+const AMOUNT_OF_WORDS_TO_CONFIRM = 4;
+
 interface SeedPhraseConfirmationProps {
   shouldShuffle?: boolean;
   seedPhrase: string;
@@ -54,7 +56,29 @@ export const SeedPhraseConfirmation: React.FC<SeedPhraseConfirmationProps> = ({
     [seedPhrase],
   );
 
+  const expectedIndexes = useMemo(
+    () =>
+      shuffle([...seedPhraseWords].map((_, idx) => idx)).slice(
+        0,
+        AMOUNT_OF_WORDS_TO_CONFIRM,
+      ),
+    [seedPhraseWords],
+  );
+
+  const expectedWords = useMemo(
+    () =>
+      seedPhraseWords.filter((_, idx) =>
+        expectedIndexes.find(index => index === idx),
+      ),
+    [seedPhraseWords],
+  );
+
+  const hasFullAnswer = result.length === expectedWords.length;
+
   const appendWord = (word: string) => {
+    if (hasFullAnswer) {
+      return;
+    }
     if (result.find(w => w === word)) {
       return;
     }
@@ -68,7 +92,7 @@ export const SeedPhraseConfirmation: React.FC<SeedPhraseConfirmationProps> = ({
   return (
     <>
       <View style={styles.mainContainer}>
-        {seedPhraseWords.map((_, idx) => (
+        {expectedWords.map((_, idx) => (
           <View
             key={idx}
             style={[styles.box, !result[idx] && styles.boxBorder]}

--- a/src/main/settings/export/components/SeedPhraseConfirmation.tsx
+++ b/src/main/settings/export/components/SeedPhraseConfirmation.tsx
@@ -17,6 +17,7 @@ interface SeedPhraseConfirmationProps {
   seedPhrase: string;
   result: string[];
   setResult: React.Dispatch<React.SetStateAction<string[]>>;
+  indexesToConfirm: number[];
 }
 
 interface WordBoxProps {
@@ -45,11 +46,18 @@ const WordBox = ({ disabled = false, onPress, word }: WordBoxProps) => {
   );
 };
 
+// Shuffles indexes and returns a sorted array of indexes to confirm
+export const getIndexesToConfirm = (seedPhrase: string) =>
+  shuffle([...seedPhrase.split(' ')].map((_, idx) => idx))
+    .slice(0, AMOUNT_OF_WORDS_TO_CONFIRM)
+    .sort((a, b) => a - b);
+
 export const SeedPhraseConfirmation: React.FC<SeedPhraseConfirmationProps> = ({
   shouldShuffle = true,
   seedPhrase,
   result,
   setResult,
+  indexesToConfirm,
 }) => {
   const styles = useThemedStyle(themedStyle);
 
@@ -58,19 +66,10 @@ export const SeedPhraseConfirmation: React.FC<SeedPhraseConfirmationProps> = ({
     [seedPhrase],
   );
 
-  const expectedIndexes = useMemo(
-    () =>
-      shuffle([...seedPhraseWords].map((_, idx) => idx)).slice(
-        0,
-        AMOUNT_OF_WORDS_TO_CONFIRM,
-      ),
-    [seedPhraseWords],
-  );
-
   const expectedWords = useMemo(
     () =>
       seedPhraseWords.filter((_, idx) =>
-        expectedIndexes.find(index => index === idx),
+        indexesToConfirm.find(index => index === idx),
       ),
     [seedPhraseWords],
   );

--- a/src/main/settings/export/components/SeedPhraseConfirmation.tsx
+++ b/src/main/settings/export/components/SeedPhraseConfirmation.tsx
@@ -22,19 +22,21 @@ interface SeedPhraseConfirmationProps {
 interface WordBoxProps {
   onPress?: (w: string) => void;
   word: string;
+  disabled?: boolean;
 }
 
-const WordBox = ({ onPress, word }: WordBoxProps) => {
+const WordBox = ({ disabled = false, onPress, word }: WordBoxProps) => {
   const styles = useThemedStyle(themedStyle);
 
   const handleOnPress = () => onPress && onPress(word);
 
   return (
     <Pressable
+      disabled={disabled}
       onPress={handleOnPress}
       style={({ pressed }) => [
         styles.box,
-        styles.wordButton,
+        disabled ? styles.disabledWordButton : styles.wordButton,
         pressed && { opacity: 0.5 },
       ]}
     >
@@ -112,7 +114,11 @@ export const SeedPhraseConfirmation: React.FC<SeedPhraseConfirmationProps> = ({
             ]}
           >
             {!result.find(w => w === word) && (
-              <WordBox word={word} onPress={appendWord} />
+              <WordBox
+                disabled={hasFullAnswer}
+                word={word}
+                onPress={appendWord}
+              />
             )}
           </View>
         ))}
@@ -142,6 +148,9 @@ const themedStyle = (theme: Theme) =>
     },
     wordButton: {
       backgroundColor: theme.normal,
+    },
+    disabledWordButton: {
+      backgroundColor: theme.secondary,
     },
     word: {
       paddingVertical: 12,


### PR DESCRIPTION
## Description

After the joint QA session, we found that full mnemonic verification was tedious and that it could be improved by shortening it.

To do so, we get 4 (parametrised) random indexes and ask the user to just put those instead of the whole phrase. With that, the time spent confirming the mnemonic decreases considerably and shows an improvement in UX.

## Related links

- Closes #212 

## Demo

| _Demo_ |
| :---: |
| <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/cfd01ea2-3e01-469d-86ef-a098e30c0408' width=400> |