### PR TITLE
fix: add missing copy outline icon on receive screen

### DIFF
--- a/src/main/home/HomeScreen.tsx
+++ b/src/main/home/HomeScreen.tsx
@@ -11,7 +11,7 @@ import { useTheme } from 'src/shared/context/themeContext';
 import { useThemedStyle } from 'src/shared/hooks/useThemedStyle';
 import { styledColors, typography } from 'src/shared/styles';
 
-import { ReceiveScreen } from './receive/ReceiveScreen/';
+import { ReceiveScreen } from './receive/ReceiveScreen';
 import SendScanScreen from './send/SendScan';
 import { MainTabStackScreenProps } from '../MainStack';
 

--- a/src/main/home/receive/ReceiveScreen.tsx
+++ b/src/main/home/receive/ReceiveScreen.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   Dimensions,
+  Pressable,
   StyleSheet,
   TouchableOpacity,
   useColorScheme,
@@ -8,23 +9,24 @@ import {
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import Clipboard from '@react-native-clipboard/clipboard';
-
-import { RootStackNavigationProps } from 'src/shared/navigation';
-import { buttonStyle } from 'src/shared/styles';
-import { useProfilePicture, useUsername, useWallet } from 'src/shared/hooks';
-
-import ShareControl from './ShareControl';
 import { useTranslation } from 'react-i18next';
+
+import CopyOutline from 'src/shared/assets/copyOutline.svg';
 import {
   QuaiPayContent,
   QuaiPayLoader,
   QuaiPayQRCode,
   QuaiPayText,
 } from 'src/shared/components';
+import { RootStackNavigationProps } from 'src/shared/navigation';
+import { buttonStyle } from 'src/shared/styles';
+import { useProfilePicture, useUsername, useWallet } from 'src/shared/hooks';
 import { Theme } from 'src/shared/types';
 import { useThemedStyle } from 'src/shared/hooks/useThemedStyle';
 import { abbreviateAddress } from 'src/shared/services/quais';
 import { useSnackBar } from 'src/shared/context/snackBarContext';
+
+import ShareControl from './ShareControl';
 
 export const ReceiveScreen = () => {
   const { t } = useTranslation();
@@ -67,13 +69,18 @@ export const ReceiveScreen = () => {
         <QuaiPayText type="H2" style={styles.ownerName}>
           {username}
         </QuaiPayText>
-        <QuaiPayText
-          type="paragraph"
-          style={styles.walletAddress}
-          onPress={copyToClipboard}
+        <Pressable
+          onLongPress={copyToClipboard}
+          style={({ pressed }) => [
+            styles.addressContainer,
+            pressed && { opacity: 0.5 },
+          ]}
         >
-          {abbreviateAddress(wallet.address)}
-        </QuaiPayText>
+          <QuaiPayText type="paragraph" themeColor="secondary">
+            {abbreviateAddress(wallet.address)}
+          </QuaiPayText>
+          <CopyOutline />
+        </Pressable>
         <View style={styles.shareControlStyle}>
           <ShareControl share={wallet.address} />
         </View>
@@ -112,8 +119,11 @@ const themedStyle = (theme: Theme) =>
     ownerName: {
       fontSize: 20,
     },
-    walletAddress: {
-      color: theme.secondary,
+    addressContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+      marginLeft: 8, // To compensate the gap and keep address centered
     },
     shareControlStyle: {
       marginTop: 20,

--- a/src/main/home/receive/ReceiveScreen.tsx
+++ b/src/main/home/receive/ReceiveScreen.tsx
@@ -13,7 +13,7 @@ import { RootStackNavigationProps } from 'src/shared/navigation';
 import { buttonStyle } from 'src/shared/styles';
 import { useProfilePicture, useUsername, useWallet } from 'src/shared/hooks';
 
-import ShareControl from '../ShareControl';
+import ShareControl from './ShareControl';
 import { useTranslation } from 'react-i18next';
 import {
   QuaiPayContent,


### PR DESCRIPTION
## Related links

- Closes #221 

## Screenshot

| _Before_ | _After_ |
| :--: | :--: |
| <img width="400" alt="image" src="https://github.com/dominant-strategies/quaipay/assets/21087992/4b3c0dfb-fb7e-45b8-b017-d63bb24f03a3"> | <img width="400" alt="image" src="https://github.com/dominant-strategies/quaipay/assets/21087992/7424d520-42c2-46be-a806-f9b53f3b2720"> |

