### PR TITLE
fix: setup of pfp with blockie on context

### DIFF
--- a/src/main/home/receive/ReceiveScreen.tsx
+++ b/src/main/home/receive/ReceiveScreen.tsx
@@ -25,6 +25,7 @@ import { Theme } from 'src/shared/types';
 import { useThemedStyle } from 'src/shared/hooks/useThemedStyle';
 import { abbreviateAddress } from 'src/shared/services/quais';
 import { useSnackBar } from 'src/shared/context/snackBarContext';
+import { useWalletContext } from 'src/shared/context/walletContext';
 
 import ShareControl from './ShareControl';
 
@@ -34,7 +35,8 @@ export const ReceiveScreen = () => {
   const { showSnackBar } = useSnackBar();
   const isDarkMode = useColorScheme() === 'dark';
   const navigation = useNavigation<RootStackNavigationProps<'Main'>>();
-  const profilePicture = useProfilePicture();
+  const { profilePicture } = useWalletContext(); // get bare profile picture state
+  useProfilePicture(); // fetch profilePicture
   const username = useUsername();
   const wallet = useWallet();
 

--- a/src/onboarding/screens/SetupNameAndPFPScreen.tsx
+++ b/src/onboarding/screens/SetupNameAndPFPScreen.tsx
@@ -66,7 +66,7 @@ export const SetupNameAndPFPScreen: React.FC<
       if (!profilePicture) {
         await storeItem({
           key: keychainKeys.profilePicture,
-          value: walletBlockie,
+          value: indexedZones[currentWalletIndex],
         });
       }
       navigation.navigate('SetupLocation');

--- a/src/shared/components/QuaiPayCamera/QuaiPayCamera.hooks.ts
+++ b/src/shared/components/QuaiPayCamera/QuaiPayCamera.hooks.ts
@@ -16,6 +16,8 @@ import {
 } from 'src/shared/utils/seedPhrase';
 
 import { ScannerType } from './QuaiPayCamera.types';
+import { Zone } from 'src/shared/types';
+import makeBlockie from 'ethereum-blockies-base64';
 
 interface HookOutput {
   frameProcessor: (frame: Frame) => void;
@@ -50,7 +52,10 @@ const useSendAmountScannerCamera = () => {
           params: {
             amount: amount || 0,
             receiverAddress: address,
-            receiverPFP: profilePicture,
+            // TODO: replace address to generate blockie with walletObject[zone] when setup
+            receiverPFP: Zone?.[profilePicture as keyof typeof Zone]
+              ? makeBlockie(address)
+              : profilePicture,
             receiverUsername: username,
             sender: sender!,
           },

--- a/src/shared/hooks/useProfilePicture.ts
+++ b/src/shared/hooks/useProfilePicture.ts
@@ -1,5 +1,8 @@
-import { useWalletContext } from 'src/shared/context/walletContext';
 import { useEffect } from 'react';
+import makeBlockie from 'ethereum-blockies-base64';
+
+import { useWalletContext } from 'src/shared/context/walletContext';
+import { Zone } from '../types';
 
 export const useProfilePicture = (): string | undefined => {
   const { profilePicture, getProfilePicture } = useWalletContext();
@@ -8,5 +11,11 @@ export const useProfilePicture = (): string | undefined => {
       getProfilePicture();
     }
   }, [profilePicture]);
-  return profilePicture;
+  return profilePicture && checkProfilePictureStringIsZone(profilePicture)
+    ? makeBlockie(profilePicture)
+    : profilePicture;
 };
+
+// Check by indexing Zone enum. If valid, it will be true
+const checkProfilePictureStringIsZone = (s: string) =>
+  !!Zone?.[s as keyof typeof Zone];


### PR DESCRIPTION
## Description

While implementing blockie pfps, we decided to store that uri string in the context and use that everywhere.

However, we found that the string might be a little too long and thus resulting in an issue while generating the QR code to share it.

Since this is a partial fix (the actual and complete fix would be to share the whole set of addresses for a contact), we defaulted on the send flow to use the address blockie if pfp is a zone.

That last part will be followed up in upcoming PRs.

## Related links

- Closes #241 

## Proof

| _Before_ | _After_ |
| :---: | :---: |
| <img width=400 src='https://github.com/dominant-strategies/quaipay/assets/21087992/beb34fea-c455-460a-83c7-880f8fc11cbb'> | <img width="400" alt="image" src="https://github.com/dominant-strategies/quaipay/assets/21087992/d9a732f6-a022-4227-8ce9-2b288bb7be84"> |