### PR TITLE
fix: paste of mnemonic on recover flow

### DIFF
--- a/src/onboarding/screens/LoginSeedPhraseInputScreen.tsx
+++ b/src/onboarding/screens/LoginSeedPhraseInputScreen.tsx
@@ -52,7 +52,7 @@ export const LoginSeedPhraseInputScreen: React.FC<
   const [settingUpWallet, setSettingUpWallet] = useState(false);
 
   const changeWordOnPhrase = (value: string, idx: number) => {
-    setSeedPhraseWords(prevState => {
+    const newPhraseCalculator = (prevState: string[]) => {
       const parsedValue = value.split(' ');
       if (parsedValue.length <= 1) {
         // Take element on idx and replace it with value
@@ -68,8 +68,10 @@ export const LoginSeedPhraseInputScreen: React.FC<
           return parsedValue[slicedId] ? parsedValue[slicedId] : word;
         });
       }
-    });
-    setIsPhraseValid(validatePhrase(seedPhraseWords.join(' ')));
+    };
+    const newValue = newPhraseCalculator(seedPhraseWords);
+    setSeedPhraseWords(newValue);
+    setIsPhraseValid(validatePhrase(newValue.join(' ')));
   };
 
   const onSuccessful = async () => {


### PR DESCRIPTION
## Description

The issue was that after pasting it, the seedphrase variable was updating async async and the validation was not using the full value.

Now, the new value is calculated outside the seed phrase state setter and used for both setters separately.

## Related links

- Closes #226 

## Proof

| _Before_ | _After_ |
| :---: | :---: |
| <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/d69ce6fa-5c9a-403e-85dd-424a0807f4e1' width=400> | <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/b21557c8-b4bb-453b-bfab-8f80f2001dfd' width=400> |