### PR TITLE
chore: add code owners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# More info -> https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @obasilakis @hsyndeniz @juanmanso


### PR DESCRIPTION
## Description

To improve DX, we add the CODEOWNERS file that protects `main` to have only code pushed via PR's approved by them.

Those, on create of a new PR, it will automatically assign them as Reviewers.

## Related links

- Closes #250 

Codeowners more info:
- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners