### PR TITLE
feat: add coingecko integration and mock quai as 1/BTC rate

### DIFF
--- a/src/main/home/receive/ReceiveAmountInputScreen/index.tsx
+++ b/src/main/home/receive/ReceiveAmountInputScreen/index.tsx
@@ -22,6 +22,7 @@ import { Currency } from 'src/shared/types';
 import { abbreviateAddress } from 'src/shared/services/quais';
 
 import { ReceiveStackScreenProps } from '../ReceiveStack';
+import { useQuaiRate } from 'src/shared/hooks/useQuaiRate';
 
 // TODO: improve L&F by using flex
 export const ReceiveAmountInputScreen: React.FC<
@@ -32,7 +33,11 @@ export const ReceiveAmountInputScreen: React.FC<
   const profilePicture = useProfilePicture();
   const username = useUsername();
   const wallet = useWallet();
-  const { eqInput, input, keyboard, onSwap } = useAmountInput();
+  const quaiRate = useQuaiRate();
+  const { eqInput, input, keyboard, onSwap } = useAmountInput(
+    undefined,
+    quaiRate,
+  );
 
   const textColor = {
     color: isDarkMode ? styledColors.white : styledColors.black,

--- a/src/main/home/receive/ReceiveAmountScreen.tsx
+++ b/src/main/home/receive/ReceiveAmountScreen.tsx
@@ -29,6 +29,7 @@ import { abbreviateAddress } from 'src/shared/services/quais';
 
 import { ReceiveStackScreenProps } from 'src/main/home/receive/ReceiveStack';
 import ShareControl from 'src/main/home/receive/ShareControl';
+import { useQuaiRate } from 'src/shared/hooks/useQuaiRate';
 
 export const ReceiveQRScreen: React.FC<
   ReceiveStackScreenProps<'ReceiveQR'>
@@ -39,8 +40,12 @@ export const ReceiveQRScreen: React.FC<
   const { t } = useTranslation();
   const username = useUsername();
   const wallet = useWallet();
+  const quaiRate = useQuaiRate();
 
-  const { input, eqInput, onSwap } = useAmountInput(amount.toString());
+  const { input, eqInput, onSwap } = useAmountInput(
+    amount.toString(),
+    quaiRate,
+  );
   const share = () => console.log('Share triggered');
   const goToQuaiPayInfo = () => console.log('Go to QuaiPay Info');
   const styles = useThemedStyle(themedStyle);

--- a/src/main/home/send/SendAmount/index.tsx
+++ b/src/main/home/send/SendAmount/index.tsx
@@ -27,9 +27,10 @@ import { useAmountInput, useWallet } from 'src/shared/hooks';
 import { abbreviateAddress, getBalance } from 'src/shared/services/quais';
 import { Currency } from 'src/shared/types';
 import { fontStyle, styledColors } from 'src/shared/styles';
+import { useZone } from 'src/shared/hooks/useZone';
+import { useQuaiRate } from 'src/shared/hooks/useQuaiRate';
 
 import { SendStackParamList } from '../SendStack';
-import { useZone } from 'src/shared/hooks/useZone';
 
 type SendAmountScreenProps = NativeStackScreenProps<
   SendStackParamList,
@@ -42,6 +43,7 @@ const SendAmountScreen = ({ route, navigation }: SendAmountScreenProps) => {
   const { t } = useTranslation();
   const wallet = useWallet();
   const { zone } = useZone();
+  const quaiRate = useQuaiRate();
   const isDarkMode = useColorScheme() === 'dark';
   const [quaiBalance, setQuaiBalance] = React.useState(0);
   const [hideBalance, setHideBalance] = React.useState(false);
@@ -116,8 +118,8 @@ const SendAmountScreen = ({ route, navigation }: SendAmountScreenProps) => {
   };
 
   useEffect(() => {
-    if (wallet) {
-      getBalance(wallet.address, zone).then(balance =>
+    if (wallet && quaiRate) {
+      getBalance(wallet.address, zone, quaiRate.base).then(balance =>
         setQuaiBalance(balance.balanceInQuai),
       );
     }

--- a/src/main/home/send/SendAmount/index.tsx
+++ b/src/main/home/send/SendAmount/index.tsx
@@ -48,7 +48,10 @@ const SendAmountScreen = ({ route, navigation }: SendAmountScreenProps) => {
   const [quaiBalance, setQuaiBalance] = React.useState(0);
   const [hideBalance, setHideBalance] = React.useState(false);
   const inputRef = useRef<TextInput>(null);
-  const { eqInput, input, keyboard, onSwap } = useAmountInput(`${amount}`);
+  const { eqInput, input, keyboard, onSwap } = useAmountInput(
+    `${amount}`,
+    quaiRate,
+  );
 
   const shouldDisableContinueButton =
     Number(input.value) === 0 || Number(eqInput.value) === 0;

--- a/src/main/home/send/SendConfirmation/index.tsx
+++ b/src/main/home/send/SendConfirmation/index.tsx
@@ -29,6 +29,7 @@ import { allNodeData } from 'src/shared/constants/nodeData';
 import { useSnackBar } from 'src/shared/context/snackBarContext';
 import { useZone } from 'src/shared/hooks/useZone';
 import { addContact, useContacts } from 'src/shared/hooks/useContacts';
+import { useQuaiRate } from 'src/shared/hooks/useQuaiRate';
 
 type SendConfirmationScreenProps = NativeStackScreenProps<
   SendStackParamList,
@@ -43,6 +44,7 @@ function SendConfirmationScreen({ route }: SendConfirmationScreenProps) {
   const contacts = useContacts();
   const wallet = useWallet();
   const { zone } = useZone();
+  const quaiRate = useQuaiRate();
   const { showSnackBar } = useSnackBar();
   const [connectionStatus, setConnectionStatus] = useState<NetInfoState>();
   const [showError, setShowError] = useState(false);
@@ -62,6 +64,7 @@ function SendConfirmationScreen({ route }: SendConfirmationScreenProps) {
           : route.params.eqInput.value,
       ) + Number(tip)
     }`,
+    quaiRate,
   );
 
   const backgroundStyle = {

--- a/src/main/home/send/SendOverview/index.tsx
+++ b/src/main/home/send/SendOverview/index.tsx
@@ -51,13 +51,14 @@ function SendOverviewScreen({ route, navigation }: SendOverviewProps) {
   } = route.params;
   const wallet = useWallet();
   const { zone } = useZone();
+  const quaiRate = useQuaiRate();
   const { eqInput, input, onSwap } = useAmountInput(
     `${Number(amountInUSD) + Number(tipInUSD)}`,
+    quaiRate,
   );
   const [gasFee, setGasFee] = useState(0);
   const [loading, setLoading] = useState(false);
   const [showError, setShowError] = useState(false);
-  const quaiRate = useQuaiRate();
 
   const backgroundStyle = {
     backgroundColor: isDarkMode ? styledColors.black : styledColors.light,

--- a/src/main/home/send/SendTip/index.tsx
+++ b/src/main/home/send/SendTip/index.tsx
@@ -15,12 +15,14 @@ import {
 } from 'react-native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useTranslation } from 'react-i18next';
-import { SendStackParamList } from '../SendStack';
+
 import { fontStyle, styledColors } from 'src/shared/styles';
 import { abbreviateAddress } from 'src/shared/services/quais';
 import { Currency } from 'src/shared/types';
 import { QuaiPayText } from 'src/shared/components';
-import { EXCHANGE_RATE } from 'src/shared/constants/exchangeRate';
+import { useQuaiRate } from 'src/shared/hooks/useQuaiRate';
+
+import { SendStackParamList } from '../SendStack';
 
 type SendTipScreenProps = NativeStackScreenProps<SendStackParamList, 'SendTip'>;
 
@@ -29,6 +31,7 @@ const SendTipScreen = ({ route, navigation }: SendTipScreenProps) => {
     route.params;
   const { t } = useTranslation();
   const isDarkMode = useColorScheme() === 'dark';
+  const quaiRate = useQuaiRate();
 
   const [selectedTip, setSelectedTip] = useState<any>(0);
   const [customTip, setCustomTip] = useState('0');
@@ -113,35 +116,37 @@ const SendTipScreen = ({ route, navigation }: SendTipScreenProps) => {
 
   const navigateToOverview = () => {
     let tipInUSD = 0;
-    if (input.unit === Currency.USD) {
-      tipInUSD =
-        selectedTip === 'custom'
-          ? Number(customTip) * EXCHANGE_RATE
-          : ((Number(amountInUSD) * selectedTip) / 100) * EXCHANGE_RATE;
-    } else {
-      tipInUSD =
-        selectedTip === 'custom'
-          ? Number(customTip) * EXCHANGE_RATE
-          : (Number(selectedTip) / 100) * EXCHANGE_RATE;
+    if (quaiRate) {
+      if (input.unit === Currency.USD) {
+        tipInUSD =
+          selectedTip === 'custom'
+            ? Number(customTip) * quaiRate?.base
+            : ((Number(amountInUSD) * selectedTip) / 100) * quaiRate?.base;
+      } else {
+        tipInUSD =
+          selectedTip === 'custom'
+            ? Number(customTip) * quaiRate?.base
+            : (Number(selectedTip) / 100) * quaiRate?.base;
+      }
+      navigation.navigate('SendOverview', {
+        ...route.params,
+        totalAmount:
+          selectedTip === 'custom'
+            ? calculateTipAmount(
+                Number(input.value),
+                Number(customTip),
+              ).total.toString()
+            : calculateTipAmount(
+                Number(input.value),
+                Number(selectedTip),
+              ).total.toString(),
+        tip:
+          selectedTip === 'custom'
+            ? parseFloat(Number(customTip).toFixed(6))
+            : parseFloat((Number(amountInUSD) * selectedTip).toFixed(6)) / 100,
+        tipInUSD: parseFloat(tipInUSD.toFixed(6)).toString(),
+      });
     }
-    navigation.navigate('SendOverview', {
-      ...route.params,
-      totalAmount:
-        selectedTip === 'custom'
-          ? calculateTipAmount(
-              Number(input.value),
-              Number(customTip),
-            ).total.toString()
-          : calculateTipAmount(
-              Number(input.value),
-              Number(selectedTip),
-            ).total.toString(),
-      tip:
-        selectedTip === 'custom'
-          ? parseFloat(Number(customTip).toFixed(6))
-          : parseFloat((Number(amountInUSD) * selectedTip).toFixed(6)) / 100,
-      tipInUSD: parseFloat(tipInUSD.toFixed(6)).toString(),
-    });
   };
 
   const handleCustomTip = () => {
@@ -315,6 +320,7 @@ const SendTipScreen = ({ route, navigation }: SendTipScreenProps) => {
               </TouchableOpacity>
             </View>
             <TouchableOpacity
+              disabled={!quaiRate}
               onPress={navigateToOverview}
               style={[
                 styles.button,

--- a/src/main/wallet/WalletScreen.tsx
+++ b/src/main/wallet/WalletScreen.tsx
@@ -25,7 +25,6 @@ import {
   Recipient,
 } from 'src/shared/services/blockscout';
 import { quais } from 'quais';
-import { EXCHANGE_RATE } from 'src/shared/constants/exchangeRate';
 import { dateToLocaleString } from 'src/shared/services/dateUtil';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { FilterModal } from 'src/main/wallet/FilterModal';
@@ -36,6 +35,7 @@ import { useContacts, useWallet, useWalletObject } from 'src/shared/hooks';
 import { allNodeData } from 'src/shared/constants/nodeData';
 import { useTheme } from 'src/shared/context/themeContext';
 import { RootNavigator } from 'src/shared/navigation/utils';
+import { useQuaiRate } from 'src/shared/hooks/useQuaiRate';
 
 const WalletScreen: React.FC<MainTabStackScreenProps<'Wallet'>> = () => {
   const { t } = useTranslation('translation', { keyPrefix: 'wallet' });
@@ -45,6 +45,7 @@ const WalletScreen: React.FC<MainTabStackScreenProps<'Wallet'>> = () => {
   const walletObject = useWalletObject();
   const { zone } = useZone();
   const contacts = useContacts();
+  const quaiRate = useQuaiRate();
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [selectedTxDirection, setSelectedTxDirection] = useState<
     string | undefined
@@ -72,7 +73,7 @@ const WalletScreen: React.FC<MainTabStackScreenProps<'Wallet'>> = () => {
   const [balance, setBalance] = useState('0');
 
   useEffect(() => {
-    if (!contacts) {
+    if (!contacts || !quaiRate) {
       return;
     }
     setLoading(true);
@@ -117,7 +118,7 @@ const WalletScreen: React.FC<MainTabStackScreenProps<'Wallet'>> = () => {
               ...item,
               recipient,
               fiatAmount:
-                Number(quais.utils.formatEther(item.value)) * EXCHANGE_RATE,
+                Number(quais.utils.formatEther(item.value)) * quaiRate?.base,
               quaiAmount: Number(quais.utils.formatEther(item.value)),
             };
           }),
@@ -143,7 +144,7 @@ const WalletScreen: React.FC<MainTabStackScreenProps<'Wallet'>> = () => {
   // TODO: implement actual search logic
   const onSearchChange = (text: string) => console.log(text);
 
-  if (loading || !wallet || !walletObject) {
+  if (loading || !wallet || !walletObject || !quaiRate) {
     return <QuaiPayLoader text={t('loading')} />;
   }
 
@@ -165,7 +166,7 @@ const WalletScreen: React.FC<MainTabStackScreenProps<'Wallet'>> = () => {
           quaiAmount={balance.toString()}
           address={abbreviateAddress(wallet?.address as string)}
           zone={allNodeData[zone].name}
-          fiatAmount={(Number(balance) * EXCHANGE_RATE).toFixed(3)}
+          fiatAmount={(Number(balance) * quaiRate?.base).toFixed(3)}
           title={t('balance')}
         />
       </View>

--- a/src/main/wallet/WalletScreen.tsx
+++ b/src/main/wallet/WalletScreen.tsx
@@ -118,7 +118,7 @@ const WalletScreen: React.FC<MainTabStackScreenProps<'Wallet'>> = () => {
               ...item,
               recipient,
               fiatAmount:
-                Number(quais.utils.formatEther(item.value)) * quaiRate?.base,
+                Number(quais.utils.formatEther(item.value)) * quaiRate.base,
               quaiAmount: Number(quais.utils.formatEther(item.value)),
             };
           }),
@@ -166,7 +166,7 @@ const WalletScreen: React.FC<MainTabStackScreenProps<'Wallet'>> = () => {
           quaiAmount={balance.toString()}
           address={abbreviateAddress(wallet?.address as string)}
           zone={allNodeData[zone].name}
-          fiatAmount={(Number(balance) * quaiRate?.base).toFixed(3)}
+          fiatAmount={(Number(balance) * quaiRate.base).toFixed(3)}
           title={t('balance')}
         />
       </View>

--- a/src/shared/components/QuaiPayActiveAddressModal.tsx
+++ b/src/shared/components/QuaiPayActiveAddressModal.tsx
@@ -1,14 +1,16 @@
 import React, { forwardRef } from 'react';
-import { BottomSheetModal } from '@gorhom/bottom-sheet';
-import { QuaiPayBottomSheetModal, QuaiPayText } from 'src/shared/components';
-import { Theme, Zone } from 'src/shared/types';
 import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
+import { BottomSheetModal } from '@gorhom/bottom-sheet';
+
+import { Theme, Zone } from 'src/shared/types';
 import Done from 'src/shared/assets/done.svg';
 import GreyDone from 'src/shared/assets/greyDone.svg';
 import { abbreviateAddress } from 'src/shared/services/quais';
 import { useWalletContext } from 'src/shared/context/walletContext';
 import { useThemedStyle } from 'src/shared/hooks';
 import { allNodeData } from 'src/shared/constants/nodeData';
+
+import { QuaiPayBottomSheetModal, QuaiPayText } from '../components';
 
 const zones = Object.keys(Zone) as Zone[];
 

--- a/src/shared/constants/exchangeRate.ts
+++ b/src/shared/constants/exchangeRate.ts
@@ -1,1 +1,0 @@
-export const EXCHANGE_RATE = 0.005;

--- a/src/shared/context/walletContext.tsx
+++ b/src/shared/context/walletContext.tsx
@@ -114,6 +114,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({
   const getQuaiRate = async () => {
     try {
       // Mock using 1/BTC rate
+      // TODO: replace with actual value
       const btcRate = await fetchBTCRate();
       const mockedRateValue = 1 / (btcRate ?? 0.0000000000001);
 

--- a/src/shared/hooks/useAmountInput.spec.tsx
+++ b/src/shared/hooks/useAmountInput.spec.tsx
@@ -8,7 +8,14 @@ type TestComponentProps = {
 };
 
 const TestComponent: React.FC<TestComponentProps> = ({ initialAmount }) => {
-  const { eqInput, input, onSwap } = useAmountInput(initialAmount);
+  const mockedQuaiRate = {
+    base: 0.005,
+    quote: 200,
+  };
+  const { eqInput, input, onSwap } = useAmountInput(
+    initialAmount,
+    mockedQuaiRate,
+  );
 
   return (
     <div>

--- a/src/shared/hooks/useAmountInput.ts
+++ b/src/shared/hooks/useAmountInput.ts
@@ -1,12 +1,14 @@
 import { useState } from 'react';
 
 import { Currency } from 'src/shared/types';
-import { useQuaiRate } from './useQuaiRate';
+import { QuaiRate } from './useQuaiRate';
 
 const INITIAL_AMOUNT = '0';
 
-export function useAmountInput(initialAmount: string = INITIAL_AMOUNT) {
-  const quaiRate = useQuaiRate();
+export function useAmountInput(
+  initialAmount: string = INITIAL_AMOUNT,
+  quaiRate?: QuaiRate,
+) {
   const [amount, setAmount] = useState(initialAmount);
   const [unit, setUnit] = useState(Currency.USD);
   const [eqValue, setEqValue] = useState(

--- a/src/shared/hooks/useAmountInput.ts
+++ b/src/shared/hooks/useAmountInput.ts
@@ -1,16 +1,17 @@
 import { useState } from 'react';
 
-import { EXCHANGE_RATE } from 'src/shared/constants/exchangeRate';
 import { Currency } from 'src/shared/types';
+import { useQuaiRate } from './useQuaiRate';
 
 const INITIAL_AMOUNT = '0';
 
 export function useAmountInput(initialAmount: string = INITIAL_AMOUNT) {
+  const quaiRate = useQuaiRate();
   const [amount, setAmount] = useState(initialAmount);
   const [unit, setUnit] = useState(Currency.USD);
   const [eqValue, setEqValue] = useState(
     parseFloat(
-      (Number(initialAmount) / EXCHANGE_RATE).toFixed(6).toString(),
+      (Number(initialAmount) * (quaiRate?.quote ?? 0)).toFixed(6).toString(),
     ).toString(),
   );
 
@@ -25,20 +26,22 @@ export function useAmountInput(initialAmount: string = INITIAL_AMOUNT) {
   };
 
   function updateInputs(value: string) {
-    if (unit === Currency.USD) {
-      setAmount(value);
-      setEqValue(
-        parseFloat(
-          (Number(value) / EXCHANGE_RATE).toFixed(6).toString(),
-        ).toString(),
-      );
-    } else {
-      setAmount(value);
-      setEqValue(
-        parseFloat(
-          (Number(value) * EXCHANGE_RATE).toFixed(6).toString(),
-        ).toString(),
-      );
+    if (quaiRate) {
+      if (unit === Currency.USD) {
+        setAmount(value);
+        setEqValue(
+          parseFloat(
+            (Number(value) * quaiRate?.quote).toFixed(6).toString(),
+          ).toString(),
+        );
+      } else {
+        setAmount(value);
+        setEqValue(
+          parseFloat(
+            (Number(value) * quaiRate?.base).toFixed(6).toString(),
+          ).toString(),
+        );
+      }
     }
   }
 

--- a/src/shared/hooks/useQuaiRate.ts
+++ b/src/shared/hooks/useQuaiRate.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import { fetchBTCRate } from '../services/coingecko';
+
+interface QuaiRate {
+  base: number;
+  quote: number;
+}
+
+export const useQuaiRate = () => {
+  const [rate, setRate] = useState<QuaiRate>();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!rate) {
+        fetchBTCRate().then(r => {
+          const mockedRateValue = 1 / (r ?? 0.0000000000001); // We are assuming that 1 Quai = 1/BTC
+          setRate({
+            base: mockedRateValue,
+            quote: 1 / mockedRateValue,
+          });
+        });
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  return rate;
+};

--- a/src/shared/hooks/useQuaiRate.ts
+++ b/src/shared/hooks/useQuaiRate.ts
@@ -1,29 +1,25 @@
-import { useEffect, useState } from 'react';
-import { fetchBTCRate } from '../services/coingecko';
+import { useEffect } from 'react';
+import { useWalletContext } from '../context/walletContext';
 
-interface QuaiRate {
+export interface QuaiRate {
   base: number;
   quote: number;
 }
 
-export const useQuaiRate = () => {
-  const [rate, setRate] = useState<QuaiRate>();
+export const useQuaiRate = (forceUpdate = false) => {
+  const { quaiRate, getQuaiRate } = useWalletContext();
 
   useEffect(() => {
-    const fetchData = async () => {
-      if (!rate) {
-        fetchBTCRate().then(r => {
-          const mockedRateValue = 1 / (r ?? 0.0000000000001); // We are assuming that 1 Quai = 1/BTC
-          setRate({
-            base: mockedRateValue,
-            quote: 1 / mockedRateValue,
-          });
-        });
-      }
-    };
-
-    fetchData();
+    if (!quaiRate) {
+      getQuaiRate();
+    }
   }, []);
 
-  return rate;
+  useEffect(() => {
+    if (forceUpdate) {
+      getQuaiRate();
+    }
+  }, []);
+
+  return quaiRate;
 };

--- a/src/shared/services/coingecko.ts
+++ b/src/shared/services/coingecko.ts
@@ -1,0 +1,31 @@
+interface CoinGeckoResponse {
+  usd: number;
+}
+
+const COINGECKO_BASE_URL = 'https://api.coingecko.com/api/v3';
+
+// To get these ids please check the following spreadsheet:
+// https://docs.google.com/spreadsheets/d/1wTTuxXt8n9q7C4NDXqQpI3wpKu1_5bGVmP9Xz0XGSyU/edit#gid=0
+enum CoinGeckoIds {
+  BTC = 'bitcoin',
+}
+const ids = Object.values(CoinGeckoIds).join(',');
+
+// Rates, being based on USD as Crypto/USD (i.e. BTC/USD), are always
+// in base terms of the pair. That means that it represents the amount
+// of USD to buy 1 Crypto, when quote rates that represent #Crypto to
+// buy 1 USD. Base and quote rates are inverted versions of one another.
+
+// fetchRates returns base rates for the pair Crypto/USD, with "Crypto"
+// being the list of ids defined at the top of the file as a const.
+export async function fetchRates() {
+  const rates: Record<CoinGeckoIds, CoinGeckoResponse> = await fetch(
+    COINGECKO_BASE_URL + `/simple/price?ids=${ids}&vs_currencies=usd`,
+  ).then(res => res.json());
+
+  return rates;
+}
+
+export async function fetchBTCRate() {
+  return await fetchRates().then(rates => rates[CoinGeckoIds.BTC].usd);
+}

--- a/src/shared/services/quais.ts
+++ b/src/shared/services/quais.ts
@@ -1,7 +1,6 @@
 import { quais } from 'quais';
 
 import { allNodeData } from 'src/shared/constants/nodeData';
-import { EXCHANGE_RATE } from 'src/shared/constants/exchangeRate';
 
 import { CONFIRMATIONS_REQUIRED } from '../constants/quais';
 import { Zone } from 'src/shared/types';
@@ -16,7 +15,11 @@ export const getWebSocketsProvider = (zone: Zone) => {
   return new quais.providers.WebSocketProvider(nodeData.url);
 };
 
-export const getBalance = async (address: string, zone: Zone) => {
+export const getBalance = async (
+  address: string,
+  zone: Zone,
+  baseRate: number,
+) => {
   const provider = getProvider(zone);
   await provider.ready;
 
@@ -25,7 +28,7 @@ export const getBalance = async (address: string, zone: Zone) => {
 
   return {
     balanceInQuai: Number(balanceInQuai),
-    balanceInUsd: Number(balanceInQuai) * EXCHANGE_RATE,
+    balanceInUsd: Number(balanceInQuai) * baseRate,
   };
 };
 


### PR DESCRIPTION
## Description

Until now, we were using a hardcoded value for Quai rate against USD. Now, our goal is to replace the hardcoded value with a mocked one based on BTC's rate.

## Related links

- Closes #238 

## Proof

| _Demo_ |
| :---: |
| <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/16f752fa-0cf3-4fe7-847e-3c8cee756017' width=400> |