### PR TITLE
refactor: remove midway instance of Modal for QPActiveAddressModal

### DIFF
--- a/src/shared/components/QuaiPayActiveAddressModal.tsx
+++ b/src/shared/components/QuaiPayActiveAddressModal.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardRefRenderFunction, forwardRef } from 'react';
+import React, { forwardRef } from 'react';
 import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
 
@@ -22,10 +22,10 @@ interface QuaiPayActiveAddressModalProps {
   balances?: Record<string, string>;
 }
 
-const Modal: ForwardRefRenderFunction<
+export const QuaiPayActiveAddressModal = forwardRef<
   BottomSheetModal,
   QuaiPayActiveAddressModalProps
-> = ({ balances }, ref) => {
+>(({ balances }, ref) => {
   const quaiRate = useQuaiRate();
   const { zone: selectedZone, setZone, walletObject } = useWalletContext();
   const styles = useThemedStyle(themedStyle);
@@ -113,12 +113,7 @@ const Modal: ForwardRefRenderFunction<
       </ScrollView>
     </QuaiPayBottomSheetModal>
   );
-};
-
-export const QuaiPayActiveAddressModal = forwardRef<
-  BottomSheetModal,
-  QuaiPayActiveAddressModalProps
->(Modal);
+});
 
 const themedStyle = (theme: Theme) =>
   StyleSheet.create({


### PR DESCRIPTION
## Description

On the PR #239 it was asked two times why we were redefining the component and no answer was given. Thus, we decided to revert that change with this PR.

## Related links

- Closes #262 

## Regression proof

| _Demo_ |
| :---: |
| <video src='https://github.com/dominant-strategies/quaipay/assets/21087992/5bec6991-3c39-41ac-8e60-2201f21419e9' width=400> |